### PR TITLE
Implement scheduler phases 511-530

### DIFF
--- a/kernel/kernel_shared.h
+++ b/kernel/kernel_shared.h
@@ -74,6 +74,11 @@ typedef struct {
     UINTN snapshot_index;
     UINT64 latency_histogram[50];
     UINTN latency_hist_index;
+    // Scheduler phase 511+ additions
+    UINTN pulse_count;
+    UINT8 trust_penalty_buffer[8];
+    UINTN scheduler_load_prediction[4];
+    INTN trust_entropy_curve;
 } KERNEL_CONTEXT;
 
 #endif // KERNEL_SHARED_H


### PR DESCRIPTION
## Summary
- extend `KERNEL_CONTEXT` with fields required for new scheduler phases
- implement scheduler phases 511-530 in `scheduler_mind.c`
- update the phase runner to execute the new phases

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_685bf1d63cc0832fa081f8d5edabb054