### PR TITLE
Implement IO mind phases 611-640

### DIFF
--- a/kernel/io_mind.c
+++ b/kernel/io_mind.c
@@ -1,4 +1,4 @@
-// io_mind.c - AiOS IO Mind (Phases 561-600)
+// io_mind.c - AiOS IO Mind (Phases 561-640)
 
 #include "kernel_shared.h"
 
@@ -330,9 +330,300 @@ static EFI_STATUS IO_InitPhase600_FinalizeIOMind(KERNEL_CONTEXT *ctx) {
     return EFI_SUCCESS;
 }
 
+// === Phases 611-640: advanced IO trust & entropy management ===
+
+static EFI_STATUS IO_InitPhase611_PredictiveIOIntentCluster(KERNEL_CONTEXT *ctx) {
+    UINTN cluster = AsmReadTsc() & 3;
+    ctx->io_active_device = cluster;
+    Telemetry_LogEvent("IO_IntentCluster", cluster, ctx->hotspot_cpu);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase612_EntropySafeMultiQueueAllocator(KERNEL_CONTEXT *ctx) {
+    UINTN high = 0, low = 0;
+    for (UINTN d = 0; d < IO_MAX_DEVICES; ++d) {
+        if (ctx->device_entropy_map[d] > 300) {
+            ctx->io_queue_stall[d % 8] = 1;
+            high++;
+        } else {
+            ctx->io_queue_stall[d % 8] = 0;
+            low++;
+        }
+        if (ctx->device_entropy_map[d] > 500)
+            ctx->io_latency_flags[d] = 1;
+    }
+    Telemetry_LogEvent("IO_MultiQueue", high, low);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase613_PCIeTrustBoundaryEnforcer(KERNEL_CONTEXT *ctx) {
+    UINTN isolated = 0;
+    for (UINTN d = 0; d < IO_MAX_DEVICES; ++d) {
+        if ((AsmReadTsc() & 0xF) == 0) {
+            ctx->io_latency_flags[d] = 1;
+            if (ctx->io_trust_map[0] > 0) ctx->io_trust_map[0]--;
+            isolated++;
+        }
+    }
+    Telemetry_LogEvent("IO_PCIBoundary", isolated, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase614_IOPageFusionAgent(KERNEL_CONTEXT *ctx) {
+    for (UINTN d = 0; d < IO_MAX_DEVICES - 1; ++d) {
+        if (ctx->device_entropy_map[d] == ctx->device_entropy_map[d + 1])
+            ctx->device_entropy_map[d] &= ~1ULL;
+    }
+    Telemetry_LogEvent("IO_PageFusion", 0, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase615_ThermalDeviceBalancer(KERNEL_CONTEXT *ctx) {
+    UINTN shifts = 0;
+    for (UINTN d = 0; d < IO_MAX_DEVICES; ++d) {
+        if ((AsmReadTsc() & 0x1FF) > 200) {
+            ctx->io_queue_stall[d % 8]++;
+            shifts++;
+        }
+    }
+    Telemetry_LogEvent("IO_ThermalBal", shifts, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase616_IOTrustPenaltyDecayTimer(KERNEL_CONTEXT *ctx) {
+    for (UINTN i = 0; i < IO_TRUST_CLASSES; ++i)
+        if (ctx->io_trust_map[i] < 50)
+            ctx->io_trust_map[i]++;
+    Telemetry_LogEvent("IO_PenaltyDecay", ctx->io_trust_map[0], ctx->io_trust_map[1]);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase617_LatencyGhostDetector(KERNEL_CONTEXT *ctx) {
+    UINTN ghosts = 0;
+    for (UINTN d = 0; d < IO_MAX_DEVICES; ++d)
+        if ((AsmReadTsc() & 0xFF) > 220)
+            ghosts++;
+    Telemetry_LogEvent("IO_GhostLatency", ghosts, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase618_EntropyAwareRAIDPathSelector(KERNEL_CONTEXT *ctx) {
+    UINTN best = 0;
+    for (UINTN d = 1; d < 4 && d < IO_MAX_DEVICES; ++d)
+        if (ctx->device_entropy_map[d] < ctx->device_entropy_map[best])
+            best = d;
+    ctx->io_active_device = best;
+    Telemetry_LogEvent("IO_RAIDSelect", best, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase619_AIBackchannelFlowControl(KERNEL_CONTEXT *ctx) {
+    if (Trust_GetCurrentScore() < 30)
+        ctx->io_sleep_state = TRUE;
+    Telemetry_LogEvent("IO_Backchannel", ctx->io_sleep_state, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase620_TrustStateSnapshotCompressor(KERNEL_CONTEXT *ctx) {
+    for (UINTN i = 0; i < IO_TRUST_CLASSES; ++i) {
+        UINT64 prev = ctx->io_entropy_buffer[i];
+        ctx->io_entropy_buffer[i] = ctx->io_trust_map[i];
+        ctx->io_trust_curves[i] = ctx->io_trust_map[i] - prev;
+    }
+    Telemetry_LogEvent("IO_TrustSnap", (UINTN)ctx->io_trust_curves[0], (UINTN)ctx->io_trust_curves[1]);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase621_EntropyThresholdReactor(KERNEL_CONTEXT *ctx) {
+    if (ctx->entropy_gap < 3) {
+        ctx->io_sleep_state = TRUE;
+        ctx->io_miss_count++;
+    }
+    Telemetry_LogEvent("IO_EntropyReact", ctx->io_sleep_state, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase622_InterPhaseDeviceStabilizer(KERNEL_CONTEXT *ctx) {
+    UINTN throttled = 0;
+    for (UINTN d = 0; d < IO_MAX_DEVICES; ++d) {
+        if (ctx->io_latency_flags[d] && ((AsmReadTsc() & 1) == 0)) {
+            ctx->io_queue_stall[d % 8]++;
+            throttled++;
+        }
+    }
+    Telemetry_LogEvent("IO_DeviceStab", throttled, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase623_DMAAnomalyFenceBuilder(KERNEL_CONTEXT *ctx) {
+    UINTN blocked = 0;
+    for (UINTN d = 0; d < IO_MAX_DEVICES; ++d) {
+        if ((AsmReadTsc() & 0x7) == 0) {
+            ctx->io_latency_flags[d] = 1;
+            ctx->io_miss_count++;
+            blocked++;
+        }
+    }
+    Telemetry_LogEvent("IO_DMAFence", blocked, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase624_MaliciousPeripheralDetector(KERNEL_CONTEXT *ctx) {
+    UINTN bad = 0;
+    for (UINTN d = 0; d < IO_MAX_DEVICES; ++d) {
+        if ((AsmReadTsc() & 0x3) == 0) {
+            if (ctx->io_trust_map[0] > 0) ctx->io_trust_map[0]--;
+            bad++;
+        }
+    }
+    Telemetry_LogEvent("IO_Malicious", bad, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase625_TrustBasedIOFairnessAuditor(KERNEL_CONTEXT *ctx) {
+    UINTN adjust = 0;
+    for (UINTN i = 0; i < IO_TRUST_CLASSES; ++i) {
+        if (ctx->io_trust_map[i] > 80) {
+            ctx->io_trust_map[i]--;
+            adjust++;
+        }
+    }
+    Telemetry_LogEvent("IO_FairAudit", adjust, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase626_IOCoreSyncPulse(KERNEL_CONTEXT *ctx) {
+    ctx->pulse_count++;
+    Telemetry_LogEvent("IO_SyncPulse", ctx->pulse_count, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase627_IODriveHeuristicsMapper(KERNEL_CONTEXT *ctx) {
+    UINTN hint = AsmReadTsc() & 0xFF;
+    AICore_ReportPhase("IO_DriveHint", hint);
+    Telemetry_LogEvent("IO_DriveMap", hint, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase628_USBTrustFrameCompressor(KERNEL_CONTEXT *ctx) {
+    for (UINTN d = 0; d < IO_MAX_DEVICES; ++d)
+        if ((AsmReadTsc() & 0x3) == 0)
+            ctx->io_latency_flags[d] = 0;
+    Telemetry_LogEvent("IO_USBFrame", 0, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase629_IOEntropyDesyncDetector(KERNEL_CONTEXT *ctx) {
+    UINTN desync = 0;
+    for (UINTN d = 0; d < IO_MAX_DEVICES; ++d) {
+        if ((ctx->device_entropy_map[d] & 0xFF) != (AsmReadTsc() & 0xFF))
+            desync++;
+    }
+    if (desync)
+        ctx->io_sleep_state = TRUE;
+    Telemetry_LogEvent("IO_EntropyDesync", desync, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase630_BehavioralDeviceScorer(KERNEL_CONTEXT *ctx) {
+    UINTN score = 0;
+    for (UINTN d = 0; d < IO_MAX_DEVICES; ++d)
+        score += AsmReadTsc() & 0x3;
+    ctx->avg_trust = (ctx->avg_trust + score) / 2;
+    Telemetry_LogEvent("IO_DeviceScore", score, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase631_TrustZoneIOShaper(KERNEL_CONTEXT *ctx) {
+    for (UINTN d = 0; d < IO_MAX_DEVICES; ++d)
+        if (ctx->io_trust_map[0] < 20)
+            ctx->io_queue_stall[d % 8]++;
+    Telemetry_LogEvent("IO_ZoneShaper", ctx->io_trust_map[0], 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase632_IOTrustAnomalyResponder(KERNEL_CONTEXT *ctx) {
+    if (ctx->io_miss_count > 10)
+        AICore_ReportEvent("IO_AnomalyDump");
+    Telemetry_LogEvent("IO_AnomalyResp", ctx->io_miss_count, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase633_EntropyBudgetEnforcer(KERNEL_CONTEXT *ctx) {
+    UINTN canceled = 0;
+    for (UINTN d = 0; d < IO_MAX_DEVICES; ++d) {
+        if (ctx->device_entropy_map[d] > 600 && ctx->io_trust_map[0] < 50) {
+            ctx->io_queue_stall[d % 8]++;
+            canceled++;
+        }
+    }
+    Telemetry_LogEvent("IO_BudgetEnforce", canceled, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase634_DetachedThreadIOMonitor(KERNEL_CONTEXT *ctx) {
+    UINTN bumps = 0;
+    for (UINTN q = 0; q < 8; ++q)
+        if ((AsmReadTsc() & 0xF) == 0) {
+            ctx->io_queue_stall[q]++;
+            bumps++;
+        }
+    Telemetry_LogEvent("IO_DetachedMon", bumps, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase635_IntentEntropyDeltaTracker(KERNEL_CONTEXT *ctx) {
+    UINTN delta = AsmReadTsc() & 0xFF;
+    ctx->entropy_gap = (ctx->entropy_gap + delta) >> 1;
+    Telemetry_LogEvent("IO_IntentDelta", delta, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase636_EntropyTransparentWriteDelay(KERNEL_CONTEXT *ctx) {
+    if (ctx->io_trust_map[0] < 30)
+        ctx->io_miss_count++;
+    Telemetry_LogEvent("IO_WriteDelay", ctx->io_miss_count, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase637_IOSecurityZoneTracer(KERNEL_CONTEXT *ctx) {
+    for (UINTN d = 0; d < IO_MAX_DEVICES; ++d)
+        ctx->io_latency_flags[d] |= (AsmReadTsc() & 1);
+    Telemetry_LogEvent("IO_SecTrace", 0, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase638_AIHardwareModelSync(KERNEL_CONTEXT *ctx) {
+    UINTN model = AsmReadTsc() & 0xFF;
+    AICore_ReportPhase("IO_HWSync", model);
+    Telemetry_LogEvent("IO_HWModel", model, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase639_SparseEntropyHandler(KERNEL_CONTEXT *ctx) {
+    UINTN sparse = 0;
+    for (UINTN d = 0; d < IO_MAX_DEVICES; ++d) {
+        if (ctx->device_entropy_map[d] < 50) {
+            ctx->io_queue_stall[d % 8]++;
+            sparse++;
+        }
+    }
+    Telemetry_LogEvent("IO_SparseEntropy", sparse, 0);
+    return EFI_SUCCESS;
+}
+
+static EFI_STATUS IO_InitPhase640_TrustRecoveryPulse(KERNEL_CONTEXT *ctx) {
+    if ((ctx->total_phases % 10) == 0)
+        for (UINTN i = 0; i < IO_TRUST_CLASSES; ++i)
+            if (ctx->io_trust_map[i] < 50)
+                ctx->io_trust_map[i]++;
+    Telemetry_LogEvent("IO_TrustPulse", ctx->io_trust_map[0], 0);
+    return EFI_SUCCESS;
+}
+
 EFI_STATUS IOMind_RunAllPhases(KERNEL_CONTEXT *ctx) {
     EFI_STATUS Status;
-    for (UINTN phase = 561; phase <= 600; ++phase) {
+    for (UINTN phase = 561; phase <= 640; ++phase) {
         switch (phase) {
             case 561: Status = IO_InitPhase561_BootstrapIOMind(ctx); break;
             case 562: Status = IO_InitPhase562_MapDeviceEntropyProfiles(ctx); break;
@@ -374,6 +665,39 @@ EFI_STATUS IOMind_RunAllPhases(KERNEL_CONTEXT *ctx) {
             case 598: Status = IO_InitPhase598_TrustLeakGuard(ctx); break;
             case 599: Status = IO_InitPhase599_IOBootEntropyStamp(ctx); break;
             case 600: Status = IO_InitPhase600_FinalizeIOMind(ctx); break;
+            case 601: case 602: case 603: case 604: case 605:
+            case 606: case 607: case 608: case 609: case 610:
+                Status = EFI_SUCCESS; break;
+            case 611: Status = IO_InitPhase611_PredictiveIOIntentCluster(ctx); break;
+            case 612: Status = IO_InitPhase612_EntropySafeMultiQueueAllocator(ctx); break;
+            case 613: Status = IO_InitPhase613_PCIeTrustBoundaryEnforcer(ctx); break;
+            case 614: Status = IO_InitPhase614_IOPageFusionAgent(ctx); break;
+            case 615: Status = IO_InitPhase615_ThermalDeviceBalancer(ctx); break;
+            case 616: Status = IO_InitPhase616_IOTrustPenaltyDecayTimer(ctx); break;
+            case 617: Status = IO_InitPhase617_LatencyGhostDetector(ctx); break;
+            case 618: Status = IO_InitPhase618_EntropyAwareRAIDPathSelector(ctx); break;
+            case 619: Status = IO_InitPhase619_AIBackchannelFlowControl(ctx); break;
+            case 620: Status = IO_InitPhase620_TrustStateSnapshotCompressor(ctx); break;
+            case 621: Status = IO_InitPhase621_EntropyThresholdReactor(ctx); break;
+            case 622: Status = IO_InitPhase622_InterPhaseDeviceStabilizer(ctx); break;
+            case 623: Status = IO_InitPhase623_DMAAnomalyFenceBuilder(ctx); break;
+            case 624: Status = IO_InitPhase624_MaliciousPeripheralDetector(ctx); break;
+            case 625: Status = IO_InitPhase625_TrustBasedIOFairnessAuditor(ctx); break;
+            case 626: Status = IO_InitPhase626_IOCoreSyncPulse(ctx); break;
+            case 627: Status = IO_InitPhase627_IODriveHeuristicsMapper(ctx); break;
+            case 628: Status = IO_InitPhase628_USBTrustFrameCompressor(ctx); break;
+            case 629: Status = IO_InitPhase629_IOEntropyDesyncDetector(ctx); break;
+            case 630: Status = IO_InitPhase630_BehavioralDeviceScorer(ctx); break;
+            case 631: Status = IO_InitPhase631_TrustZoneIOShaper(ctx); break;
+            case 632: Status = IO_InitPhase632_IOTrustAnomalyResponder(ctx); break;
+            case 633: Status = IO_InitPhase633_EntropyBudgetEnforcer(ctx); break;
+            case 634: Status = IO_InitPhase634_DetachedThreadIOMonitor(ctx); break;
+            case 635: Status = IO_InitPhase635_IntentEntropyDeltaTracker(ctx); break;
+            case 636: Status = IO_InitPhase636_EntropyTransparentWriteDelay(ctx); break;
+            case 637: Status = IO_InitPhase637_IOSecurityZoneTracer(ctx); break;
+            case 638: Status = IO_InitPhase638_AIHardwareModelSync(ctx); break;
+            case 639: Status = IO_InitPhase639_SparseEntropyHandler(ctx); break;
+            case 640: Status = IO_InitPhase640_TrustRecoveryPulse(ctx); break;
             default: Status = EFI_INVALID_PARAMETER; break;
         }
         if (EFI_ERROR(Status)) {


### PR DESCRIPTION
## Summary
- extend io_mind.c to cover phases 611-640
- implement logic for new advanced IO phases
- update phase loop in `IOMind_RunAllPhases` to execute phases up to 640

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_685bf634ef94832f9ceaec0dc15d7d2b