### PR TITLE
Add SelfCoder phases 10000-10050

### DIFF
--- a/include/ai_selfcoder.h
+++ b/include/ai_selfcoder.h
@@ -1,0 +1,61 @@
+#ifndef AI_SELFCODER_H
+#define AI_SELFCODER_H
+
+#include <Uefi.h>
+#include "kernel_shared.h"
+
+EFI_STATUS SelfCoder_InitPhase10000_EnableAutoEvolution(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10001_BootstrapSeedPlanner(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10002_StartGeneratorLoop(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10003_SandboxPhaseExecutor(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10004_DNAApprovalWriteback(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10005_CommitPhaseSet(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10006_AdvisoryConflictResolver(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10007_RollbackStrategyPlanner(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10008_TrustForecastAllocator(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10009_EntropyBudgetIssuer(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10010_PredictivePhaseThreadMapper(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10011_MemorySafetyFuzzer(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10012_TelemetryPhaseImpactLogger(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10013_LivePhaseEntropyScanner(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10014_AIIntentAnchorGenerator(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10015_StructuralPhasePatternValidator(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10016_AdaptiveRetryScheduler(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10017_GPUDelegateGenerator(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10018_AdvisoryCorrectionLoopback(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10019_PhaseSignatureFingerprinter(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10020_EntropyLeakDetectionAgent(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10021_PhaseBehaviorMapper(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10022_TrustRegressionForecaster(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10023_EntropyOverheadProfiler(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10024_AIIntentionCrosscheckAgent(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10025_RollbackQuorumMonitor(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10026_AdvisoryCollisionChecker(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10027_SelfcoderContextSnapshotter(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10028_MemoryAllocationRationalizer(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10029_InstructionEfficiencyScorer(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10030_TrustConstrainedAdvisorTuner(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10031_TrustDriftRegulator(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10032_RecursiveEntropyReplayGuard(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10033_IntentAlignmentValidator(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10034_EnergyCostEstimator(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10035_PhaseInstructionMapCompiler(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10036_SandboxTimingStabilizer(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10037_PredictiveEntropyAllocator(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10038_InstructionPathConformer(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10039_TrustDifferentialAnalyzer(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10040_FeedbackLoopDetector(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10041_TrustSanityEnforcer(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10042_EntropySpikeSuppressor(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10043_PhaseSimilarityDetector(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10044_PhaseCompactnessOptimizer(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10045_AdvisoryMismatchResolver(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10046_GPUPhaseCostScaler(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10047_InstructionRerankerEngine(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10048_ZeroDayTrapPatternFlagger(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10049_RecursivePhaseAmplificationFilter(KERNEL_CONTEXT *ctx);
+EFI_STATUS SelfCoder_InitPhase10050_DNAConflictResolver(KERNEL_CONTEXT *ctx);
+
+EFI_STATUS SelfCoder_RunAllPhases(KERNEL_CONTEXT *ctx);
+
+#endif // AI_SELFCODER_H

--- a/kernel/ai_selfcoder.c
+++ b/kernel/ai_selfcoder.c
@@ -1,0 +1,359 @@
+#include "ai_selfcoder.h"
+#include "ai_core.h"
+#include "trust_mind.h"
+#include "telemetry_mind.h"
+#include "sha256.h"
+#include <Library/BaseMemoryLib.h>
+#include <Library/BaseLib.h>
+
+// Simple stubs for prediction and validation
+static void PredictNextNeed(UINT64 out[3]) {
+    for (UINTN i = 0; i < 3; ++i)
+        out[i] = AsmReadTsc() ^ i;
+}
+
+static EFI_STATUS Trust_ValidateProposal(UINT64 val) {
+    Telemetry_LogEvent("ValidateProposal", (UINTN)val, 0);
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10000_EnableAutoEvolution(KERNEL_CONTEXT *ctx) {
+    ctx->selfcoder_active = TRUE;
+    ZeroMem(ctx->phase_queue, sizeof(ctx->phase_queue));
+    ZeroMem(ctx->selfcoder_trust_matrix, sizeof(ctx->selfcoder_trust_matrix));
+    AICore_AttachToBootDNA("selfcoder_active", ctx->trust_score);
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10001_BootstrapSeedPlanner(KERNEL_CONTEXT *ctx) {
+    UINT64 plan[3];
+    PredictNextNeed(plan);
+    for (UINTN i = 0; i < 3; ++i)
+        ctx->selfcoder_plan[i] = plan[i];
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10002_StartGeneratorLoop(KERNEL_CONTEXT *ctx) {
+    for (UINTN i = 0; i < 3; ++i)
+        ctx->generation_log[i] = ctx->selfcoder_plan[i];
+    Telemetry_LogEvent("GenLoop", ctx->generation_log[0], 0);
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10003_SandboxPhaseExecutor(KERNEL_CONTEXT *ctx) {
+    ctx->sandbox_result = 0;
+    UINT64 delta = AsmReadTsc() & 0xFF;
+    if (delta < 200)
+        ctx->sandbox_result = 1;
+    ctx->EntropyScore ^= delta;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10004_DNAApprovalWriteback(KERNEL_CONTEXT *ctx) {
+    SHA256_CTX c;
+    UINT8 hash[SHA256_DIGEST_LENGTH];
+    sha256_init(&c);
+    sha256_update(&c, (UINT8 *)ctx->generation_log, sizeof(ctx->generation_log));
+    sha256_final(&c, hash);
+    ctx->boot_dna_history[0] = *(UINT64 *)hash;
+    AICore_AttachToBootDNA("selfcoder_commit", ctx->trust_score);
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10005_CommitPhaseSet(KERNEL_CONTEXT *ctx) {
+    ctx->phase_queue[0] = ctx->boot_dna_history[0];
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10006_AdvisoryConflictResolver(KERNEL_CONTEXT *ctx) {
+    ctx->conflict_log[0] = ctx->phase_queue[0];
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10007_RollbackStrategyPlanner(KERNEL_CONTEXT *ctx) {
+    ctx->rollback_slot[0] = ctx->phase_queue[0];
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10008_TrustForecastAllocator(KERNEL_CONTEXT *ctx) {
+    ctx->trust_slope[0] = Trust_GetCurrentScore();
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10009_EntropyBudgetIssuer(KERNEL_CONTEXT *ctx) {
+    ctx->phase_budget[0] = ctx->EntropyScore & 0xFF;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10010_PredictivePhaseThreadMapper(KERNEL_CONTEXT *ctx) {
+    ctx->phase_queue[1] = ctx->selfcoder_plan[0];
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10011_MemorySafetyFuzzer(KERNEL_CONTEXT *ctx) {
+    ctx->sandbox_status = 0;
+    if ((AsmReadTsc() & 0xF) == 0)
+        ctx->sandbox_status = 1;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10012_TelemetryPhaseImpactLogger(KERNEL_CONTEXT *ctx) {
+    Telemetry_LogEvent("SelfCoderImpact", ctx->EntropyScore, ctx->trust_score);
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10013_LivePhaseEntropyScanner(KERNEL_CONTEXT *ctx) {
+    if ((ctx->EntropyScore & 0xF) > 8)
+        ctx->sandbox_status = 2;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10014_AIIntentAnchorGenerator(KERNEL_CONTEXT *ctx) {
+    ctx->behavior_log[0] = ctx->intent_alignment_score;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10015_StructuralPhasePatternValidator(KERNEL_CONTEXT *ctx) {
+    ctx->behavior_log[1] = ctx->phase_queue[0];
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10016_AdaptiveRetryScheduler(KERNEL_CONTEXT *ctx) {
+    ctx->rollback_slot[1] = ctx->sandbox_result;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10017_GPUDelegateGenerator(KERNEL_CONTEXT *ctx) {
+    ctx->phase_opcode_map[0] = ctx->ai_scheduler_weight;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10018_AdvisoryCorrectionLoopback(KERNEL_CONTEXT *ctx) {
+    ctx->ai_advisory_signature[0] = (UINT8)(ctx->trust_score & 0xFF);
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10019_PhaseSignatureFingerprinter(KERNEL_CONTEXT *ctx) {
+    SHA256_CTX c;
+    UINT8 h[SHA256_DIGEST_LENGTH];
+    sha256_init(&c);
+    sha256_update(&c, (UINT8 *)ctx->generation_log, sizeof(ctx->generation_log));
+    sha256_final(&c, h);
+    ctx->dna_phase_fingerprint[0] = *(UINT64 *)h;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10020_EntropyLeakDetectionAgent(KERNEL_CONTEXT *ctx) {
+    if (ctx->EntropyScore > 200)
+        ctx->sandbox_status = 3;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10021_PhaseBehaviorMapper(KERNEL_CONTEXT *ctx) {
+    ctx->behavior_log[1] = ctx->EntropyScore;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10022_TrustRegressionForecaster(KERNEL_CONTEXT *ctx) {
+    ctx->trust_slope[1] = ctx->trust_score;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10023_EntropyOverheadProfiler(KERNEL_CONTEXT *ctx) {
+    ctx->entropy_budget[0] = ctx->EntropyScore;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10024_AIIntentionCrosscheckAgent(KERNEL_CONTEXT *ctx) {
+    ctx->behavior_log[2] = ctx->intent_alignment_score;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10025_RollbackQuorumMonitor(KERNEL_CONTEXT *ctx) {
+    ctx->rollback_slot[2] = ctx->boot_dna_history[0];
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10026_AdvisoryCollisionChecker(KERNEL_CONTEXT *ctx) {
+    ctx->conflict_log[1] = ctx->ai_advisory_signature[0];
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10027_SelfcoderContextSnapshotter(KERNEL_CONTEXT *ctx) {
+    ctx->boot_dna_history[1] = ctx->EntropyScore ^ ctx->trust_score;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10028_MemoryAllocationRationalizer(KERNEL_CONTEXT *ctx) {
+    ctx->phase_budget[1] = ctx->EntropyScore / 2;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10029_InstructionEfficiencyScorer(KERNEL_CONTEXT *ctx) {
+    ctx->behavior_log[3] = ctx->trust_score / (ctx->EntropyScore + 1);
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10030_TrustConstrainedAdvisorTuner(KERNEL_CONTEXT *ctx) {
+    Trust_ValidateProposal(ctx->trust_score);
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10031_TrustDriftRegulator(KERNEL_CONTEXT *ctx) {
+    ctx->trust_slope[2] = ctx->trust_score;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10032_RecursiveEntropyReplayGuard(KERNEL_CONTEXT *ctx) {
+    ctx->entropy_budget[1] = ctx->EntropyScore;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10033_IntentAlignmentValidator(KERNEL_CONTEXT *ctx) {
+    if (ctx->intent_alignment_score == 0)
+        ctx->sandbox_status = 4;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10034_EnergyCostEstimator(KERNEL_CONTEXT *ctx) {
+    ctx->entropy_budget[3] = AsmReadTsc() & 0xFFFF;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10035_PhaseInstructionMapCompiler(KERNEL_CONTEXT *ctx) {
+    ctx->phase_opcode_map[1] = ctx->generation_log[0];
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10036_SandboxTimingStabilizer(KERNEL_CONTEXT *ctx) {
+    ctx->phase_queue[2] = AsmReadTsc() & 0xFF;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10037_PredictiveEntropyAllocator(KERNEL_CONTEXT *ctx) {
+    ctx->entropy_budget[2] = ctx->EntropyScore / 2;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10038_InstructionPathConformer(KERNEL_CONTEXT *ctx) {
+    ctx->phase_opcode_map[2] = ctx->phase_queue[0];
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10039_TrustDifferentialAnalyzer(KERNEL_CONTEXT *ctx) {
+    ctx->trust_slope[3] = ctx->trust_score - ctx->avg_trust;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10040_FeedbackLoopDetector(KERNEL_CONTEXT *ctx) {
+    ctx->phase_budget[2] |= 1;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10041_TrustSanityEnforcer(KERNEL_CONTEXT *ctx) {
+    if (ctx->trust_score > 100)
+        ctx->trust_score = 100;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10042_EntropySpikeSuppressor(KERNEL_CONTEXT *ctx) {
+    if (ctx->EntropyScore > 300)
+        ctx->EntropyScore = 300;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10043_PhaseSimilarityDetector(KERNEL_CONTEXT *ctx) {
+    ctx->conflict_log[2] = ctx->phase_queue[0];
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10044_PhaseCompactnessOptimizer(KERNEL_CONTEXT *ctx) {
+    ctx->phase_opcode_map[3] = ctx->phase_opcode_map[0];
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10045_AdvisoryMismatchResolver(KERNEL_CONTEXT *ctx) {
+    ctx->conflict_log[3] = ctx->conflict_log[0];
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10046_GPUPhaseCostScaler(KERNEL_CONTEXT *ctx) {
+    ctx->phase_budget[4] = ctx->ai_scheduler_weight;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10047_InstructionRerankerEngine(KERNEL_CONTEXT *ctx) {
+    ctx->phase_opcode_map[4] = ctx->generation_log[0];
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10048_ZeroDayTrapPatternFlagger(KERNEL_CONTEXT *ctx) {
+    if (ctx->phase_queue[0] & 1) ctx->sandbox_status = 5;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10049_RecursivePhaseAmplificationFilter(KERNEL_CONTEXT *ctx) {
+    ctx->phase_budget[5] = 1;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_InitPhase10050_DNAConflictResolver(KERNEL_CONTEXT *ctx) {
+    ctx->boot_dna_history[2] = ctx->dna_phase_fingerprint[0];
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS SelfCoder_RunAllPhases(KERNEL_CONTEXT *ctx) {
+    EFI_STATUS Status;
+    Status = SelfCoder_InitPhase10000_EnableAutoEvolution(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10001_BootstrapSeedPlanner(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10002_StartGeneratorLoop(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10003_SandboxPhaseExecutor(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10004_DNAApprovalWriteback(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10005_CommitPhaseSet(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10006_AdvisoryConflictResolver(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10007_RollbackStrategyPlanner(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10008_TrustForecastAllocator(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10009_EntropyBudgetIssuer(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10010_PredictivePhaseThreadMapper(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10011_MemorySafetyFuzzer(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10012_TelemetryPhaseImpactLogger(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10013_LivePhaseEntropyScanner(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10014_AIIntentAnchorGenerator(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10015_StructuralPhasePatternValidator(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10016_AdaptiveRetryScheduler(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10017_GPUDelegateGenerator(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10018_AdvisoryCorrectionLoopback(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10019_PhaseSignatureFingerprinter(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10020_EntropyLeakDetectionAgent(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10021_PhaseBehaviorMapper(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10022_TrustRegressionForecaster(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10023_EntropyOverheadProfiler(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10024_AIIntentionCrosscheckAgent(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10025_RollbackQuorumMonitor(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10026_AdvisoryCollisionChecker(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10027_SelfcoderContextSnapshotter(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10028_MemoryAllocationRationalizer(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10029_InstructionEfficiencyScorer(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10030_TrustConstrainedAdvisorTuner(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10031_TrustDriftRegulator(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10032_RecursiveEntropyReplayGuard(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10033_IntentAlignmentValidator(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10034_EnergyCostEstimator(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10035_PhaseInstructionMapCompiler(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10036_SandboxTimingStabilizer(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10037_PredictiveEntropyAllocator(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10038_InstructionPathConformer(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10039_TrustDifferentialAnalyzer(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10040_FeedbackLoopDetector(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10041_TrustSanityEnforcer(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10042_EntropySpikeSuppressor(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10043_PhaseSimilarityDetector(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10044_PhaseCompactnessOptimizer(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10045_AdvisoryMismatchResolver(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10046_GPUPhaseCostScaler(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10047_InstructionRerankerEngine(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10048_ZeroDayTrapPatternFlagger(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10049_RecursivePhaseAmplificationFilter(ctx); if (EFI_ERROR(Status)) return Status;
+    Status = SelfCoder_InitPhase10050_DNAConflictResolver(ctx); if (EFI_ERROR(Status)) return Status;
+    return EFI_SUCCESS;
+}

--- a/kernel/kernel_shared.h
+++ b/kernel/kernel_shared.h
@@ -120,6 +120,23 @@ typedef struct {
     UINT8   ai_advisory_signature[32];
     UINT8   ai_state;
     BOOLEAN ai_finalized;
+    /* Selfcoder fields */
+    BOOLEAN selfcoder_active;
+    UINT64  phase_queue[8];
+    UINT64  selfcoder_trust_matrix[4][4];
+    UINT64  selfcoder_plan[3];
+    UINT64  generation_log[16];
+    UINT8   sandbox_result;
+    UINT8   sandbox_status;
+    UINT64  boot_dna_history[16];
+    UINT64  conflict_log[8];
+    UINT64  rollback_slot[8];
+    UINT64  phase_budget[16];
+    UINT64  behavior_log[16];
+    UINT64  dna_phase_fingerprint[16];
+    UINT64  entropy_budget[16];
+    UINT64  phase_opcode_map[16];
+    UINT64  trust_slope[16];
 } KERNEL_CONTEXT;
 
 #endif // KERNEL_SHARED_H


### PR DESCRIPTION
## Summary
- implement new SelfCoder module with phases 10000-10050
- declare phase prototypes in `ai_selfcoder.h`
- extend `KERNEL_CONTEXT` with state used by self-coder logic

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_685c13c88f00832fb1d271e167514741