### PR TITLE
Implement AI core phases 701-750

### DIFF
--- a/include/ai_core.h
+++ b/include/ai_core.h
@@ -34,6 +34,58 @@ UINTN AICore_ScoreStorageMindPerformance(KERNEL_CONTEXT *ctx);
 
 EFI_STATUS AICore_SendToTelemetry(void);
 
+// AI Core initialization phases 701-750
+EFI_STATUS AICorePhase701_InitializeSubsystem(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase702_TrustMatrixBootstrap(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase703_PredictiveEntropyVectorInit(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase704_MemoryTrendClassifier(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase705_ReasoningConfidenceBoost(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase706_EntropyImpactModeler(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase707_TrustCurveGenerator(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase708_SeedPredictionCache(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase709_SelfValidation(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase710_PerformanceProfiler(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase711_IntentAlignmentEvaluator(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase712_EntropyDriftDetector(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase713_TrustBackpropagation(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase714_ReasoningStateSync(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase715_RuleWeightBalancer(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase716_EntropySignatureGenerator(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase717_TrustShockAbsorber(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase718_AdaptivePredictionRegulator(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase719_ContextAwarenessEnabler(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase720_TrainingCyclePlanner(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase721_EffectivenessHeuristicUpdater(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase722_SupervisionLayerValidator(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase723_EntropyUsageScorer(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase724_FinalizationCheck(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase725_RootHashVerifier(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase726_ShutdownHandoffPrep(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase727_PredictiveTrustValidator(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase728_AnomalySuppressor(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase729_SelfFeedbackLoop(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase730_FinalStateExporter(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase731_PolicyInfluenceBalancer(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase732_TrustRecoveryForecaster(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase733_EntropyTrustCorrelationScanner(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase734_AnomalyScoreEmitter(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase735_EntropyInputCompressor(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase736_TrustSlopeTracker(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase737_EntropyHistoryCleaner(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase738_LatencyImpactEstimator(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase739_ThermalAdjuster(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase740_EnergyEfficiencyEvaluator(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase741_TrustWaveGenerator(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase742_GlobalSyncEnabler(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase743_LocalMinimaDetector(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase744_ResilienceCalculator(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase745_EntropyCyclePredictor(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase746_ActionAdvisor(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase747_IntegrityHashEmitter(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase748_TrustAlignmentCheck(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase749_ShutdownEntropyReducer(KERNEL_CONTEXT *ctx);
+EFI_STATUS AICorePhase750_FinalHeartbeatEmission(KERNEL_CONTEXT *ctx);
+
 // AI Core initialization phases 861-900
 EFI_STATUS AICore_InitPhase861_BootstrapAICore(KERNEL_CONTEXT *ctx);
 EFI_STATUS AICore_InitPhase862_SystemIntentRecognizer(KERNEL_CONTEXT *ctx);

--- a/kernel/kernel_shared.h
+++ b/kernel/kernel_shared.h
@@ -122,6 +122,7 @@ typedef struct {
     BOOLEAN ai_gpu_delegate_ready;
     UINT64  ai_scheduler_weight;
     UINT8   entropy_usage_percent;
+    UINT8   thermal_advisory;
     UINT64  ai_root_reasoning_tree_hash;
     INT16   ai_rule_weights[961];
     UINT64  ai_trust_matrix[10][10];
@@ -129,6 +130,7 @@ typedef struct {
     UINT64  ai_prediction_cache[32];
     UINT8   ai_advisory_signature[32];
     UINT8   ai_state;
+    BOOLEAN ai_alignment_confirmed;
     BOOLEAN ai_finalized;
 } KERNEL_CONTEXT;
 


### PR DESCRIPTION
## Summary
- add prototypes for AI core phases 701-750
- implement phase logic for 701-750 in `ai_core.c`
- extend `KERNEL_CONTEXT` with `thermal_advisory` and `ai_alignment_confirmed`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c28c41e80832fa6c8a633c4eb8cf0