### PR TITLE
Implement trust phases 651-700

### DIFF
--- a/kernel/kernel_shared.h
+++ b/kernel/kernel_shared.h
@@ -128,6 +128,11 @@ typedef struct {
     UINT64  trust_normalized[20];
     UINT64  meta_trust_score;
     UINT64  shared_trust_cache[8];
+    struct {
+        UINT64 trust;
+        UINT64 entropy;
+    } entropy_snapshot_buffer[32];
+    UINTN entropy_snapshot_index;
     /* AI core fields */
     UINT64 ai_global_trust_score;
     UINT8  ai_status;


### PR DESCRIPTION
## Summary
- add persistent entropy snapshot buffer to kernel context
- implement phases 651-700 in trust_mind with new behaviors

## Testing
- `make -n`

------
https://chatgpt.com/codex/tasks/task_e_685c67ab74a0832f9dd4bbb263fb7159