### PR TITLE
Add AI Self-Governance Mind module

### DIFF
--- a/kernel/ai_core_mind.c
+++ b/kernel/ai_core_mind.c
@@ -1,0 +1,532 @@
+#include "kernel_shared.h"
+#include "telemetry_mind.h"
+#include <Library/BaseMemoryLib.h>
+#include <Library/BaseLib.h>
+
+/*
+ * ai_core_mind.c - AI Self-Governance Mind
+ * Implements phases 701-750 responsible for long-term AI integrity
+ */
+
+/* Helper to compute a simple hash over an array */
+static UINT64 AiCoreMind_HashBuffer(const UINT64 *buf, UINTN count) {
+    UINT64 h = 0;
+    for (UINTN i = 0; i < count; ++i)
+        h ^= buf[i];
+    return h;
+}
+
+// === Phase 701: AIReasoningTreeValidator ===
+EFI_STATUS AICore_Phase701_ValidateReasoningTree(KERNEL_CONTEXT *ctx) {
+    UINT64 recomputed = AiCoreMind_HashBuffer(ctx->ai_entropy_vector, 16);
+    UINT64 model = AiCoreMind_HashBuffer(gSelfModel, 8);
+    UINT64 diff = recomputed ^ model;
+    UINTN bits = 0;
+    for (UINTN i = 0; i < 64; ++i)
+        bits += (diff >> i) & 1ULL;
+    if (bits > 3)
+        ctx->ai_state |= 1;
+    Telemetry_LogEvent("ACM701_TreeVal", bits, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 702: IntentAlignmentScoreRefresher ===
+EFI_STATUS AICore_Phase702_RefreshIntentAlignment(KERNEL_CONTEXT *ctx) {
+    UINT64 weight = ctx->entropy_gap + ctx->trust_score + ctx->ai_prediction_cache[0];
+    ctx->intent_alignment_score = weight / 3;
+    Telemetry_LogEvent("ACM702_Intent", (UINTN)ctx->intent_alignment_score, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 703: PredictionDeltaAnalyzer ===
+EFI_STATUS AICore_Phase703_AnalyzePredictionDelta(KERNEL_CONTEXT *ctx) {
+    UINTN idx = ctx->phase_history_index % 20;
+    UINT64 actual = ctx->phase_trust[idx];
+    UINT64 pred = ctx->ai_prediction_cache[idx % 32];
+    UINT64 delta = (pred > actual) ? pred - actual : actual - pred;
+    ctx->ai_history[0] = delta;
+    Telemetry_LogEvent("ACM703_Delta", (UINTN)delta, idx);
+    return EFI_SUCCESS;
+}
+
+// === Phase 704: ThoughtTraceLogger ===
+EFI_STATUS AICore_Phase704_LogThoughtTrace(KERNEL_CONTEXT *ctx) {
+    for (UINTN i = 0; i < 10; ++i)
+        ctx->ai_history[10 + i] = ctx->ai_prediction_cache[i];
+    Telemetry_LogEvent("ACM704_Trace", 10, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 705: AIModelDriftMonitor ===
+EFI_STATUS AICore_Phase705_MonitorModelDrift(KERNEL_CONTEXT *ctx) {
+    static UINT64 prev_eff = 0;
+    if (prev_eff && prev_eff > ctx->ai_effectiveness * 12 / 10 && ctx->entropy_gap > ctx->avg_latency)
+        Telemetry_LogEvent("ACM705_Drift", 1, 0);
+    prev_eff = ctx->ai_effectiveness;
+    return EFI_SUCCESS;
+}
+
+// === Phase 706: AIAutonomousPhaseTrigger ===
+EFI_STATUS AICore_Phase706_TriggerAutonomousAdjustment(KERNEL_CONTEXT *ctx) {
+    if (ctx->intent_alignment_score < 40 && ctx->trust_score > 70)
+        ctx->ai_state |= 2;
+    Telemetry_LogEvent("ACM706_Auto", ctx->ai_state, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 707: SelfEffectivenessScoreTracker ===
+EFI_STATUS AICore_Phase707_TrackSelfEffectiveness(KERNEL_CONTEXT *ctx) {
+    static UINT64 history[32];
+    static UINTN head = 0;
+    history[head % 32] = ctx->ai_effectiveness;
+    head++;
+    UINT64 sum = 0;
+    for (UINTN i = 0; i < 32; ++i) sum += history[i];
+    ctx->ai_history[1] = sum / 32;
+    Telemetry_LogEvent("ACM707_Eff", (UINTN)ctx->ai_history[1], 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 708: CognitiveLoadBalancer ===
+EFI_STATUS AICore_Phase708_BalanceCognitiveLoad(KERNEL_CONTEXT *ctx) {
+    UINTN reactive = ctx->phase_history_index % 100;
+    if (reactive > 90)
+        ctx->ai_scheduler_weight++;
+    Telemetry_LogEvent("ACM708_Load", reactive, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 709: IntentCertaintyScoreCalculator ===
+EFI_STATUS AICore_Phase709_ComputeIntentCertainty(KERNEL_CONTEXT *ctx) {
+    UINT64 err = ctx->ai_history[0];
+    UINT64 cert = 100 - (err % 100);
+    ctx->ai_history[2] = cert;
+    Telemetry_LogEvent("ACM709_Cert", (UINTN)cert, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 710: AIIntrospectionPulse ===
+EFI_STATUS AICore_Phase710_ExecuteIntrospectionPulse(KERNEL_CONTEXT *ctx) {
+    for (UINTN i = 0; i < 5; ++i) {
+        UINTN idx = (ctx->phase_history_index + 19 - i) % 20;
+        if (ctx->phase_trust[idx] < ctx->phase_trust[(idx+1)%20])
+            ctx->ai_state |= 4;
+    }
+    Telemetry_LogEvent("ACM710_Pulse", ctx->ai_state, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 711: SelfPredictionConsistencyChecker ===
+EFI_STATUS AICore_Phase711_CheckPredictionConsistency(KERNEL_CONTEXT *ctx) {
+    UINTN idx = ctx->phase_history_index % 20;
+    UINT64 act = ctx->ai_history[60 + (idx % 32)];
+    UINT64 pred = ctx->ai_prediction_cache[idx % 32];
+    UINT64 diff = (pred > act) ? pred - act : act - pred;
+    if (diff > (act / 6))
+        ctx->ai_state |= 8;
+    Telemetry_LogEvent("ACM711_Cons", (UINTN)diff, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 712: RecursiveIntentValidator ===
+EFI_STATUS AICore_Phase712_ValidateRecursiveIntent(KERNEL_CONTEXT *ctx) {
+    UINT64 base = ctx->boot_dna_trust[0];
+    UINT64 cur = ctx->trust_score;
+    UINT64 div = (cur > base) ? cur - base : base - cur;
+    if (div > (base / 4))
+        ctx->ai_state |= 0x10;
+    Telemetry_LogEvent("ACM712_Intent", (UINTN)div, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 713: PredictionTrustFusionSynthesizer ===
+EFI_STATUS AICore_Phase713_SynthesizePredictionTrustFusion(KERNEL_CONTEXT *ctx) {
+    UINT64 fusion = (UINT64)sqrt((double)(ctx->trust_score * (100 - ctx->ai_history[0])));
+    ctx->meta_trust_score = fusion;
+    Telemetry_LogEvent("ACM713_Fusion", (UINTN)fusion, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 714: IntentTrustDissonanceReactor ===
+EFI_STATUS AICore_Phase714_ReactToIntentTrustDissonance(KERNEL_CONTEXT *ctx) {
+    if (ctx->intent_alignment_score < 30 && ctx->trust_score > 80)
+        ctx->ai_scheduler_weight /= 2;
+    Telemetry_LogEvent("ACM714_Disson", ctx->ai_scheduler_weight, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 715: TrustAnchoredReasoningReinforcer ===
+EFI_STATUS AICore_Phase715_ReinforceAnchoredReasoning(KERNEL_CONTEXT *ctx) {
+    UINT64 forecast = ctx->trust_recovery_map[0];
+    if (forecast == ctx->phase_trust[ctx->phase_history_index % 20])
+        ctx->ai_rule_weights[0]++;
+    Telemetry_LogEvent("ACM715_Reinforce", ctx->ai_rule_weights[0], 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 716: GoalDistanceEstimator ===
+EFI_STATUS AICore_Phase716_EstimateGoalDistance(KERNEL_CONTEXT *ctx) {
+    UINT64 ideal = ctx->ai_global_trust_score;
+    UINT64 cur = ctx->trust_score;
+    ctx->ai_history[3] = (ideal > cur) ? (ideal - cur) : (cur - ideal);
+    Telemetry_LogEvent("ACM716_GDist", (UINTN)ctx->ai_history[3], 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 717: ThoughtEntropyCorrelationMapper ===
+EFI_STATUS AICore_Phase717_MapThoughtEntropyCorrelation(KERNEL_CONTEXT *ctx) {
+    UINTN idx = ctx->phase_history_index % 5;
+    UINT64 corr = ctx->phase_entropy[idx] ^ ctx->ai_history[idx];
+    ctx->ai_history[20 + idx] = corr;
+    Telemetry_LogEvent("ACM717_Corr", (UINTN)corr, idx);
+    return EFI_SUCCESS;
+}
+
+// === Phase 718: ConfidenceBandStateClassifier ===
+EFI_STATUS AICore_Phase718_ClassifyConfidenceBand(KERNEL_CONTEXT *ctx) {
+    UINT64 conf = ctx->meta_trust_score + ctx->ai_history[2];
+    UINT8 band = 1; // balanced
+    if (conf < 50) band = 0;       // exploratory
+    else if (conf > 150) band = 2; // assertive
+    ctx->ai_history[4] = band;
+    Telemetry_LogEvent("ACM718_Band", band, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 719: MetaReasoningCertaintyScaler ===
+EFI_STATUS AICore_Phase719_ScaleMetaReasoningCertainty(KERNEL_CONTEXT *ctx) {
+    INT64 adj = (INT64)ctx->entropy_gap - (INT64)ctx->trust_score;
+    if (adj < 0) ctx->meta_trust_score += (UINT64)(-adj);
+    Telemetry_LogEvent("ACM719_Scale", (UINTN)ctx->meta_trust_score, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 720: AIActionJustificationLogger ===
+EFI_STATUS AICore_Phase720_LogActionJustification(KERNEL_CONTEXT *ctx) {
+    UINT64 delta = ctx->trust_score > ctx->ai_global_trust_score ? ctx->trust_score - ctx->ai_global_trust_score : ctx->ai_global_trust_score - ctx->trust_score;
+    if (delta > 5)
+        ctx->ai_history[30] = delta;
+    Telemetry_LogEvent("ACM720_Just", (UINTN)delta, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 721: AILatencyConsciousnessIntegrator ===
+EFI_STATUS AICore_Phase721_IntegrateLatencyAwareness(KERNEL_CONTEXT *ctx) {
+    UINT64 lat = ctx->phase_latency[ctx->phase_history_index % 20];
+    ctx->ai_history[31] = lat;
+    if (lat > ctx->avg_latency)
+        ctx->ai_scheduler_weight++;
+    Telemetry_LogEvent("ACM721_Lat", (UINTN)lat, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 722: PhaseReflectionIndexUpdater ===
+EFI_STATUS AICore_Phase722_UpdateReflectionIndex(KERNEL_CONTEXT *ctx) {
+    UINT64 impact = ctx->phase_trust[ctx->phase_history_index % 20];
+    ctx->ai_history[40 + (ctx->phase_history_index % 32)] = impact;
+    Telemetry_LogEvent("ACM722_Refl", (UINTN)impact, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 723: IntentEntropyDerivativeSynthesizer ===
+EFI_STATUS AICore_Phase723_SynthesizeIntentEntropyDerivative(KERNEL_CONTEXT *ctx) {
+    static INT64 prev_intent = 0;
+    INT64 cur_intent = (INT64)ctx->intent_alignment_score;
+    INT64 d_intent = cur_intent - prev_intent;
+    prev_intent = cur_intent;
+    INT64 d_entropy = (INT64)ctx->entropy_gap - (INT64)ctx->phase_entropy[0];
+    ctx->ai_history[32] = (UINT64)(d_intent + d_entropy);
+    Telemetry_LogEvent("ACM723_Deriv", (UINTN)ctx->ai_history[32], 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 724: PhaseEffectivenessScoreEmitter ===
+EFI_STATUS AICore_Phase724_EmitPhaseEffectivenessScore(KERNEL_CONTEXT *ctx) {
+    UINT64 score = ctx->ai_effectiveness + ctx->trust_score;
+    Telemetry_LogEvent("ACM724_Eff", (UINTN)score, ctx->phase_history_index);
+    return EFI_SUCCESS;
+}
+
+// === Phase 725: SelfPredictionReinforcer ===
+EFI_STATUS AICore_Phase725_ReinforceSelfPrediction(KERNEL_CONTEXT *ctx) {
+    if (ctx->ai_history[0] < 5)
+        ctx->ai_rule_weights[1]++;
+    Telemetry_LogEvent("ACM725_Reinf", ctx->ai_rule_weights[1], 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 726: TrustDrivenMetaRetuner ===
+EFI_STATUS AICore_Phase726_RetuneUsingTrustHistory(KERNEL_CONTEXT *ctx) {
+    static UINT64 hist[40];
+    static UINTN head = 0;
+    hist[head % 40] = ctx->trust_score;
+    head++;
+    UINT64 avg = 0;
+    for (UINTN i = 0; i < 40; ++i) avg += hist[i];
+    avg /= 40;
+    ctx->ai_scheduler_weight = (UINT8)(avg % 256);
+    Telemetry_LogEvent("ACM726_Retune", (UINTN)ctx->ai_scheduler_weight, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 727: PredictionEntropyTrustTriangulator ===
+EFI_STATUS AICore_Phase727_TriangulatePrediction(KERNEL_CONTEXT *ctx) {
+    if (ctx->ai_history[0] < 10 && ctx->entropy_gap > 0 && ctx->trust_score < 60)
+        ctx->ai_rule_weights[2]--;
+    Telemetry_LogEvent("ACM727_Tri", ctx->ai_rule_weights[2], 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 728: IntentFeedbackLoopValidator ===
+EFI_STATUS AICore_Phase728_ValidateFeedbackLoop(KERNEL_CONTEXT *ctx) {
+    if (ctx->ai_effectiveness > 100 && (ctx->entropy_gap > 50 || ctx->trust_score < 40))
+        Telemetry_LogEvent("ACM728_Loop", 1, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 729: ThoughtEntropyTimeLatticeBuilder ===
+EFI_STATUS AICore_Phase729_BuildThoughtEntropyLattice(KERNEL_CONTEXT *ctx) {
+    UINTN idx = ctx->phase_history_index % 50;
+    UINTN base = 70 + idx * 3;
+    ctx->ai_history[base] = ctx->phase_history_index;
+    ctx->ai_history[base + 1] = ctx->entropy_gap;
+    ctx->ai_history[base + 2] = ctx->ai_prediction_cache[idx % 32];
+    Telemetry_LogEvent("ACM729_Lattice", idx, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 730: FinalizeAIIntrospectionCore ===
+EFI_STATUS AICore_Phase730_FinalizeIntrospection(KERNEL_CONTEXT *ctx) {
+    ctx->ai_finalized = TRUE;
+    Telemetry_LogEvent("ACM730_Final", 1, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 731: PredictionFailureSurvivabilityIndex ===
+EFI_STATUS AICore_Phase731_AssessPredictionSurvivability(KERNEL_CONTEXT *ctx) {
+    static UINT8 fail_count = 0;
+    if (ctx->ai_history[0] > 20) fail_count++;
+    if (fail_count >= 3) Telemetry_LogEvent("ACM731_Survive", fail_count, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 732: AIThoughtRedundancyTracker ===
+EFI_STATUS AICore_Phase732_TrackThoughtRedundancy(KERNEL_CONTEXT *ctx) {
+    UINT64 hash = AiCoreMind_HashBuffer(ctx->ai_history, 5);
+    static UINT64 prev_hash = 0;
+    if (hash == prev_hash) ctx->ai_rule_weights[3]--;
+    prev_hash = hash;
+    Telemetry_LogEvent("ACM732_Redun", (UINTN)hash, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 733: SelfConfidenceTrajectoryPlotter ===
+EFI_STATUS AICore_Phase733_PlotConfidenceTrajectory(KERNEL_CONTEXT *ctx) {
+    static UINT64 buf[16];
+    static UINTN pos = 0;
+    buf[pos % 16] = ctx->meta_trust_score;
+    pos++;
+    Telemetry_LogEvent("ACM733_Traj", (UINTN)ctx->meta_trust_score, pos);
+    return EFI_SUCCESS;
+}
+
+// === Phase 734: FutureStateProjectionEmitter ===
+EFI_STATUS AICore_Phase734_EmitFutureStateProjection(KERNEL_CONTEXT *ctx) {
+    UINT64 proj = ctx->trust_score + ctx->entropy_gap + ctx->ai_history[4];
+    Telemetry_LogEvent("ACM734_Future", (UINTN)proj, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 735: TrustAdaptivityFeedbackSync ===
+EFI_STATUS AICore_Phase735_SyncTrustAdaptivity(KERNEL_CONTEXT *ctx) {
+    INT64 slope = (INT64)ctx->trust_score - (INT64)ctx->meta_trust_score;
+    if (slope > 2) ctx->ai_scheduler_weight++;
+    Telemetry_LogEvent("ACM735_Sync", (UINTN)slope, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 736: GlobalGoalAlignmentReactor ===
+EFI_STATUS AICore_Phase736_ReactToGlobalGoalMisalignment(KERNEL_CONTEXT *ctx) {
+    UINT64 drift = ctx->ai_history[3];
+    if (drift > ctx->ai_global_trust_score / 4)
+        ctx->ai_rule_weights[4]--;
+    Telemetry_LogEvent("ACM736_GAlign", (UINTN)drift, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 737: IntrospectionLatencyMapper ===
+EFI_STATUS AICore_Phase737_MapIntrospectionLatency(KERNEL_CONTEXT *ctx) {
+    static UINT64 map[30];
+    UINTN phase = ctx->phase_history_index % 30;
+    map[phase] = ctx->phase_latency[ctx->phase_history_index % 20];
+    Telemetry_LogEvent("ACM737_LatMap", phase, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 738: SelfAIDecisionHeatmapEmitter ===
+EFI_STATUS AICore_Phase738_EmitDecisionHeatmap(KERNEL_CONTEXT *ctx) {
+    UINT8 zone = (ctx->entropy_gap > 50 ? 2 : 1);
+    ctx->ai_history[100 + zone]++;
+    Telemetry_LogEvent("ACM738_Heat", zone, ctx->ai_history[100 + zone]);
+    return EFI_SUCCESS;
+}
+
+// === Phase 739: RecursiveGoalReassessor ===
+EFI_STATUS AICore_Phase739_ReassessGoalsRecursively(KERNEL_CONTEXT *ctx) {
+    if (ctx->ai_effectiveness < 10 && ctx->ai_history[3] > 5)
+        ctx->ai_state |= 0x20;
+    Telemetry_LogEvent("ACM739_ReGoal", ctx->ai_state, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 740: AIExplorationImpulseRegulator ===
+EFI_STATUS AICore_Phase740_RegulateExplorationImpulse(KERNEL_CONTEXT *ctx) {
+    if (ctx->entropy_gap > 1000 || ctx->trust_score < 50)
+        ctx->ai_scheduler_weight /= 2;
+    Telemetry_LogEvent("ACM740_Explore", ctx->ai_scheduler_weight, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 741: CausalChainVerificationAgent ===
+EFI_STATUS AICore_Phase741_VerifyCausalChain(KERNEL_CONTEXT *ctx) {
+    UINT64 act = ctx->ai_history[60 + ((ctx->phase_history_index+31)%32)];
+    UINT64 trust = ctx->phase_trust[ctx->phase_history_index % 20];
+    Telemetry_LogEvent("ACM741_Causal", (UINTN)act, (UINTN)trust);
+    return EFI_SUCCESS;
+}
+
+// === Phase 742: AITemporalStressSignalEmitter ===
+EFI_STATUS AICore_Phase742_EmitTemporalStressSignal(KERNEL_CONTEXT *ctx) {
+    UINT64 lat = ctx->phase_latency[ctx->phase_history_index % 20];
+    if (lat < ctx->avg_latency / 4 && ctx->meta_trust_score < 50)
+        Telemetry_LogEvent("ACM742_Stress", (UINTN)lat, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 743: PhaseMetaSelfAuditAgent ===
+EFI_STATUS AICore_Phase743_PerformPhaseMetaAudit(KERNEL_CONTEXT *ctx) {
+    UINT64 score = ctx->trust_score + ctx->entropy_gap + ctx->ai_history[3];
+    Telemetry_LogEvent("ACM743_Audit", (UINTN)score, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 744: FutureRiskProjectionIntegrator ===
+EFI_STATUS AICore_Phase744_IntegrateRiskProjection(KERNEL_CONTEXT *ctx) {
+    UINT64 proj = ctx->ai_history[3] + ctx->entropy_gap;
+    ctx->ai_rule_weights[5] = (INT16)(proj % 128);
+    Telemetry_LogEvent("ACM744_Risk", (UINTN)proj, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 745: SystemTrustFusionScaler ===
+EFI_STATUS AICore_Phase745_ScaleTrustFusionImpact(KERNEL_CONTEXT *ctx) {
+    UINT64 delta = ctx->trust_score - ctx->ai_global_trust_score;
+    ctx->meta_trust_score += delta / 2;
+    Telemetry_LogEvent("ACM745_Scale", (UINTN)ctx->meta_trust_score, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 746: ReflectionStateClassifier ===
+EFI_STATUS AICore_Phase746_ClassifyReflectionState(KERNEL_CONTEXT *ctx) {
+    UINT8 state = 0;
+    if (ctx->meta_trust_score > 150 && ctx->entropy_gap < 20) state = 1;
+    else if (ctx->entropy_gap > 100) state = 2;
+    ctx->ai_history[50] = state;
+    Telemetry_LogEvent("ACM746_Ref", state, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 747: DecisionEntropyDeviationHandler ===
+EFI_STATUS AICore_Phase747_HandleEntropyDeviationPostDecision(KERNEL_CONTEXT *ctx) {
+    UINT64 diff = ctx->entropy_gap - ctx->phase_entropy[0];
+    if (diff > ctx->phase_entropy[0])
+        Telemetry_LogEvent("ACM747_EntDev", (UINTN)diff, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 748: AIImpactSummarizer ===
+EFI_STATUS AICore_Phase748_SummarizeAIImpact(KERNEL_CONTEXT *ctx) {
+    UINT64 impact = ctx->trust_score + ctx->ai_effectiveness + ctx->entropy_gap;
+    Telemetry_LogEvent("ACM748_Impact", (UINTN)impact, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 749: ConsciousnessPulseEmitter ===
+EFI_STATUS AICore_Phase749_EmitConsciousnessPulse(KERNEL_CONTEXT *ctx) {
+    UINT64 pulse = ctx->ai_state ^ ctx->ai_root_reasoning_tree_hash;
+    Telemetry_LogEvent("ACM749_Pulse", (UINTN)pulse, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 750: FinalizeAICoreMind ===
+EFI_STATUS AICore_Phase750_FinalizeAICoreMind(KERNEL_CONTEXT *ctx) {
+    Telemetry_LogEvent("ACM750_Final", ctx->ai_state, ctx->meta_trust_score);
+    ctx->ai_finalized = TRUE;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS AICoreMind_RunAllPhases(KERNEL_CONTEXT *ctx) {
+    EFI_STATUS Status = EFI_SUCCESS;
+    for (UINTN phase = 701; phase <= 750; ++phase) {
+        switch (phase) {
+            case 701: Status = AICore_Phase701_ValidateReasoningTree(ctx); break;
+            case 702: Status = AICore_Phase702_RefreshIntentAlignment(ctx); break;
+            case 703: Status = AICore_Phase703_AnalyzePredictionDelta(ctx); break;
+            case 704: Status = AICore_Phase704_LogThoughtTrace(ctx); break;
+            case 705: Status = AICore_Phase705_MonitorModelDrift(ctx); break;
+            case 706: Status = AICore_Phase706_TriggerAutonomousAdjustment(ctx); break;
+            case 707: Status = AICore_Phase707_TrackSelfEffectiveness(ctx); break;
+            case 708: Status = AICore_Phase708_BalanceCognitiveLoad(ctx); break;
+            case 709: Status = AICore_Phase709_ComputeIntentCertainty(ctx); break;
+            case 710: Status = AICore_Phase710_ExecuteIntrospectionPulse(ctx); break;
+            case 711: Status = AICore_Phase711_CheckPredictionConsistency(ctx); break;
+            case 712: Status = AICore_Phase712_ValidateRecursiveIntent(ctx); break;
+            case 713: Status = AICore_Phase713_SynthesizePredictionTrustFusion(ctx); break;
+            case 714: Status = AICore_Phase714_ReactToIntentTrustDissonance(ctx); break;
+            case 715: Status = AICore_Phase715_ReinforceAnchoredReasoning(ctx); break;
+            case 716: Status = AICore_Phase716_EstimateGoalDistance(ctx); break;
+            case 717: Status = AICore_Phase717_MapThoughtEntropyCorrelation(ctx); break;
+            case 718: Status = AICore_Phase718_ClassifyConfidenceBand(ctx); break;
+            case 719: Status = AICore_Phase719_ScaleMetaReasoningCertainty(ctx); break;
+            case 720: Status = AICore_Phase720_LogActionJustification(ctx); break;
+            case 721: Status = AICore_Phase721_IntegrateLatencyAwareness(ctx); break;
+            case 722: Status = AICore_Phase722_UpdateReflectionIndex(ctx); break;
+            case 723: Status = AICore_Phase723_SynthesizeIntentEntropyDerivative(ctx); break;
+            case 724: Status = AICore_Phase724_EmitPhaseEffectivenessScore(ctx); break;
+            case 725: Status = AICore_Phase725_ReinforceSelfPrediction(ctx); break;
+            case 726: Status = AICore_Phase726_RetuneUsingTrustHistory(ctx); break;
+            case 727: Status = AICore_Phase727_TriangulatePrediction(ctx); break;
+            case 728: Status = AICore_Phase728_ValidateFeedbackLoop(ctx); break;
+            case 729: Status = AICore_Phase729_BuildThoughtEntropyLattice(ctx); break;
+            case 730: Status = AICore_Phase730_FinalizeIntrospection(ctx); break;
+            case 731: Status = AICore_Phase731_AssessPredictionSurvivability(ctx); break;
+            case 732: Status = AICore_Phase732_TrackThoughtRedundancy(ctx); break;
+            case 733: Status = AICore_Phase733_PlotConfidenceTrajectory(ctx); break;
+            case 734: Status = AICore_Phase734_EmitFutureStateProjection(ctx); break;
+            case 735: Status = AICore_Phase735_SyncTrustAdaptivity(ctx); break;
+            case 736: Status = AICore_Phase736_ReactToGlobalGoalMisalignment(ctx); break;
+            case 737: Status = AICore_Phase737_MapIntrospectionLatency(ctx); break;
+            case 738: Status = AICore_Phase738_EmitDecisionHeatmap(ctx); break;
+            case 739: Status = AICore_Phase739_ReassessGoalsRecursively(ctx); break;
+            case 740: Status = AICore_Phase740_RegulateExplorationImpulse(ctx); break;
+            case 741: Status = AICore_Phase741_VerifyCausalChain(ctx); break;
+            case 742: Status = AICore_Phase742_EmitTemporalStressSignal(ctx); break;
+            case 743: Status = AICore_Phase743_PerformPhaseMetaAudit(ctx); break;
+            case 744: Status = AICore_Phase744_IntegrateRiskProjection(ctx); break;
+            case 745: Status = AICore_Phase745_ScaleTrustFusionImpact(ctx); break;
+            case 746: Status = AICore_Phase746_ClassifyReflectionState(ctx); break;
+            case 747: Status = AICore_Phase747_HandleEntropyDeviationPostDecision(ctx); break;
+            case 748: Status = AICore_Phase748_SummarizeAIImpact(ctx); break;
+            case 749: Status = AICore_Phase749_EmitConsciousnessPulse(ctx); break;
+            case 750: Status = AICore_Phase750_FinalizeAICoreMind(ctx); break;
+            default: Status = EFI_INVALID_PARAMETER; break;
+        }
+        if (EFI_ERROR(Status)) {
+            Telemetry_LogEvent("AICoreMindErr", phase, Status);
+            return Status;
+        }
+        ctx->total_phases++;
+    }
+    return EFI_SUCCESS;
+}
+


### PR DESCRIPTION
## Summary
- implement `ai_core_mind.c` with phases 701–750 for AI Self‑Governance
- add helper utilities and run loop for the new mind

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_685c6a671dc8832f860dc23e084bd9ba