### PR TITLE
Implement PowerMind phases 901-930

### DIFF
--- a/include/power_mind.h
+++ b/include/power_mind.h
@@ -1,0 +1,40 @@
+#ifndef POWER_MIND_H
+#define POWER_MIND_H
+
+#include <Uefi.h>
+#include "kernel_shared.h"
+
+EFI_STATUS PowerMind_Phase901_ModelBatteryDischargeCurve(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase902_IntegrateEntropyTrust(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase903_ThrottlePhasesByPower(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase904_ControlSmartTDP(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase905_EvaluateIntentAlignment(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase906_DetectDrainAnomaly(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase907_VerifyVoltageStability(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase908_TuneForIdle(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase909_ForecastPhaseDemand(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase910_CalculateBatteryTrustIndex(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase911_LogEnergyTrustDeviation(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase912_TriggerSafeMode(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase913_MapReflectionCausality(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase914_EstimateChargeSlope(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase915_ModelEntropyImpact(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase916_SyncWithVoltageEvents(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase917_EmitFusionTelemetry(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase918_CompensatePowerDrift(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase919_ValidateThermalCoupling(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase920_ForecastIntentCost(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase921_IsolatePhaseEnergyAnomaly(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase922_SynthesizeConfidenceScore(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase923_AllocatePhasePower(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase924_OrchestrateSleepDecision(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase925_ScanBlindspots(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase926_OptimizeTrustPowerCost(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase927_ActivateOverpowerPrevention(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase928_LogConvergence(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase929_ApplyBackoffTimer(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase930_FinalizePowerMind(KERNEL_CONTEXT *ctx);
+
+EFI_STATUS PowerMind_RunAllPhases(KERNEL_CONTEXT *ctx);
+
+#endif // POWER_MIND_H

--- a/kernel/kernel_shared.h
+++ b/kernel/kernel_shared.h
@@ -205,6 +205,16 @@ typedef struct {
     UINT8   quarantine_list[16];
     BOOLEAN vlan_alert;
     BOOLEAN network_mind_ready;
+    /* Power mind fields */
+    UINT8   battery_percent;
+    INT8    battery_curve[64];
+    INT8    discharge_slope;
+    UINT64  power_anomaly_log[16];
+    BOOLEAN power_safe_mode;
+    UINT8   battery_trust_index;
+    UINT64  power_confidence_score;
+    UINT8   cpu_tdp_percent;
+    BOOLEAN power_mind_ready;
 } KERNEL_CONTEXT;
 
 #endif // KERNEL_SHARED_H

--- a/kernel/power_mind.c
+++ b/kernel/power_mind.c
@@ -1,0 +1,304 @@
+// power_mind.c - AI-native Power Mind Phases 901-930
+#include "kernel_shared.h"
+#include "power_mind.h"
+#include "telemetry_mind.h"
+#include "trust_mind.h"
+#include "ai_core.h"
+#include <Library/BaseMemoryLib.h>
+#include <Library/BaseLib.h>
+
+static UINT8 gBatteryPercentHistory[64];
+static UINTN gBatteryIdx = 0;
+static UINT64 gVoltageSamples[8];
+static UINTN gVoltIdx = 0;
+
+EFI_STATUS PowerMind_Phase901_ModelBatteryDischargeCurve(KERNEL_CONTEXT *ctx) {
+    UINT8 pct = ctx->battery_percent;
+    gBatteryPercentHistory[gBatteryIdx % 64] = pct;
+    if (gBatteryIdx > 0) {
+        INTN delta = (INTN)pct - (INTN)gBatteryPercentHistory[(gBatteryIdx - 1) % 64];
+        ctx->battery_curve[gBatteryIdx % 64] = (INT8)delta;
+        ctx->discharge_slope = delta;
+    }
+    gBatteryIdx++;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase902_IntegrateEntropyTrust(KERNEL_CONTEXT *ctx) {
+    if (ctx->trust_score < ctx->meta_trust_score || ctx->entropy_mind_ready == FALSE)
+        ctx->discharge_slope = (ctx->discharge_slope * 9) / 10;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase903_ThrottlePhasesByPower(KERNEL_CONTEXT *ctx) {
+    if (ctx->battery_percent < 15) {
+        ctx->phase_latency[ctx->phase_history_index % 20] += 10;
+    }
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase904_ControlSmartTDP(KERNEL_CONTEXT *ctx) {
+    if (ctx->ai_state == 0) {
+        ctx->cpu_tdp_percent = (ctx->cpu_tdp_percent * 75) / 100;
+    } else if (ctx->intent_alignment_score > 80) {
+        if (ctx->cpu_tdp_percent < 100)
+            ctx->cpu_tdp_percent += 5;
+    }
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase905_EvaluateIntentAlignment(KERNEL_CONTEXT *ctx) {
+    if (ctx->intent_alignment_score > 80 && ctx->battery_percent < 20) {
+        Telemetry_LogEvent("PowerIntentConflict", ctx->intent_alignment_score, ctx->battery_percent);
+    }
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase906_DetectDrainAnomaly(KERNEL_CONTEXT *ctx) {
+    if (gBatteryIdx >= 5) {
+        UINT8 recent = gBatteryPercentHistory[(gBatteryIdx - 1) % 64];
+        UINT8 prev = gBatteryPercentHistory[(gBatteryIdx - 5) % 64];
+        if (prev > recent && prev - recent > 3) {
+            ctx->power_anomaly_log[ctx->snapshot_index % 16] = AsmReadTsc();
+            Telemetry_LogEvent("PowerDrain", prev, recent);
+        }
+    }
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase907_VerifyVoltageStability(KERNEL_CONTEXT *ctx) {
+    UINT64 v = AsmReadTsc();
+    gVoltageSamples[gVoltIdx % 8] = v;
+    if (gVoltIdx >= 8) {
+        UINT64 avg = 0;
+        for (UINTN i = 0; i < 8; ++i) avg += gVoltageSamples[i];
+        avg /= 8;
+        UINT64 dev = (v > avg) ? v - avg : avg - v;
+        if (avg && dev * 100 / avg > 5)
+            Telemetry_LogEvent("VoltInstab", (UINTN)dev, (UINTN)avg);
+    }
+    gVoltIdx++;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase908_TuneForIdle(KERNEL_CONTEXT *ctx) {
+    if (ctx->ai_state == 0 && ctx->pulse_count == 0) {
+        ctx->ai_core_block_b_ready = FALSE;
+    }
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase909_ForecastPhaseDemand(KERNEL_CONTEXT *ctx) {
+    UINT64 sum = 0;
+    for (UINTN i = 0; i < 10; ++i)
+        sum += ctx->phase_latency[i];
+    ctx->entropy_load_forecast = sum;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase910_CalculateBatteryTrustIndex(KERNEL_CONTEXT *ctx) {
+    UINT64 wear = ctx->nvme_error_count + 1;
+    UINT64 cycles = ctx->nvme_unsafe_shutdowns + 1;
+    INTN slope = ctx->discharge_slope;
+    UINT64 score = 100;
+    score = score > wear ? score - wear : 0;
+    score = score > cycles ? score - cycles : 0;
+    score = (slope < 0) ? score + slope : score;
+    if (score > 100) score = 100;
+    ctx->battery_trust_index = (UINT8)score;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase911_LogEnergyTrustDeviation(KERNEL_CONTEXT *ctx) {
+    UINT64 expected = ctx->entropy_load_forecast;
+    UINT64 actual = ctx->discharge_slope < 0 ? -ctx->discharge_slope : ctx->discharge_slope;
+    if (expected && actual * 120 > expected * 100) {
+        ctx->power_anomaly_log[ctx->snapshot_index % 16] = AsmReadTsc();
+    }
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase912_TriggerSafeMode(KERNEL_CONTEXT *ctx) {
+    if (ctx->battery_percent < 5 && ctx->discharge_slope < -1) {
+        ctx->power_safe_mode = TRUE;
+    }
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase913_MapReflectionCausality(KERNEL_CONTEXT *ctx) {
+    ctx->ai_history[ctx->snapshot_index % 128] ^= ctx->entropy_load_forecast;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase914_EstimateChargeSlope(KERNEL_CONTEXT *ctx) {
+    static UINT8 prev = 0; static UINTN tick = 0; tick++;
+    if (tick % 3 == 0) {
+        UINT8 cur = ctx->battery_percent;
+        INTN rise = cur - prev;
+        ctx->battery_curve[(gBatteryIdx + tick) % 64] = (INT8)rise;
+        prev = cur;
+    }
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase915_ModelEntropyImpact(KERNEL_CONTEXT *ctx) {
+    static UINT64 accum = 0; static UINTN count = 0;
+    accum += ctx->EntropyScore * (UINT64)(ctx->discharge_slope < 0 ? -ctx->discharge_slope : ctx->discharge_slope);
+    count++;
+    if (count >= 64) {
+        ctx->entropy_thermal_correlation = accum / 64;
+        accum = 0; count = 0;
+    }
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase916_SyncWithVoltageEvents(KERNEL_CONTEXT *ctx) {
+    UINT64 cur = gVoltageSamples[(gVoltIdx + 7) % 8];
+    UINT64 prev = gVoltageSamples[(gVoltIdx + 6) % 8];
+    if (prev && (cur > prev ? cur - prev : prev - cur) > prev / 20) {
+        ctx->scheduler_pressure_mode = TRUE;
+    }
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase917_EmitFusionTelemetry(KERNEL_CONTEXT *ctx) {
+    Telemetry_LogEvent("PowerFusion", ctx->EntropyScore, ctx->battery_trust_index);
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase918_CompensatePowerDrift(KERNEL_CONTEXT *ctx) {
+    INTN model = ctx->discharge_slope;
+    INTN real = (INTN)ctx->battery_curve[(gBatteryIdx + 63) % 64];
+    if (model && (real - model) * 100 / model > 12) {
+        ctx->ai_scheduler_weight = (ctx->ai_scheduler_weight * 9) / 10;
+    }
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase919_ValidateThermalCoupling(KERNEL_CONTEXT *ctx) {
+    UINT64 power = ctx->entropy_load_forecast;
+    UINTN temp = ctx->nvme_temperature;
+    if (power > (ctx->entropy_load_forecast * 125) / 100 && temp < ctx->nvme_temperature + 2) {
+        ctx->latency_spike_alert = TRUE;
+    }
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase920_ForecastIntentCost(KERNEL_CONTEXT *ctx) {
+    UINT64 cost = ctx->intent_alignment_score * ctx->EntropyScore;
+    ctx->ai_prediction_cache[ctx->phase_history_index % 32] = cost;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase921_IsolatePhaseEnergyAnomaly(KERNEL_CONTEXT *ctx) {
+    UINT64 energy = ctx->entropy_load_forecast;
+    for (UINTN i = 0; i < 20; ++i) {
+        if (ctx->phase_entropy[i] * ctx->phase_trust[i] > energy * 85 / 100) {
+            ctx->quarantine_list[i % 16] = 1;
+        }
+    }
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase922_SynthesizeConfidenceScore(KERNEL_CONTEXT *ctx) {
+    UINT64 score = ctx->battery_trust_index;
+    score *=  ctx->entropy_thermal_correlation ? ctx->entropy_thermal_correlation : 1;
+    score *=  ctx->discharge_slope ? (UINT64)(ctx->discharge_slope * ctx->discharge_slope) : 1;
+    ctx->power_confidence_score = score;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase923_AllocatePhasePower(KERNEL_CONTEXT *ctx) {
+    UINT64 budget = ctx->EntropyScore;
+    for (UINTN i = 0; i < 10; ++i) {
+        ctx->phase_latency[i] = budget / (i + 1);
+    }
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase924_OrchestrateSleepDecision(KERNEL_CONTEXT *ctx) {
+    if (ctx->battery_percent < 20 && ctx->intent_alignment_score < 50) {
+        ctx->io_sleep_state = TRUE;
+    }
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase925_ScanBlindspots(KERNEL_CONTEXT *ctx) {
+    static UINTN steady = 0;
+    if (ctx->discharge_slope == 0)
+        steady++;
+    else
+        steady = 0;
+    if (steady > 5)
+        ctx->entropy_blindspot_flags[0] = 1;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase926_OptimizeTrustPowerCost(KERNEL_CONTEXT *ctx) {
+    if (ctx->entropy_mind_ready == FALSE) {
+        ctx->ai_scheduler_weight += 1;
+    }
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase927_ActivateOverpowerPrevention(KERNEL_CONTEXT *ctx) {
+    UINT64 draw = ctx->entropy_load_forecast + ctx->phase_latency[0];
+    if (draw > 1000) {
+        ctx->ai_gpu_delegate_ready = FALSE;
+    }
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase928_LogConvergence(KERNEL_CONTEXT *ctx) {
+    ctx->power_anomaly_log[ctx->snapshot_index % 16] = ctx->phase_history_index;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase929_ApplyBackoffTimer(KERNEL_CONTEXT *ctx) {
+    if (ctx->scheduler_pressure_mode)
+        ctx->trust_freeze_count = 10;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_Phase930_FinalizePowerMind(KERNEL_CONTEXT *ctx) {
+    for (UINTN i = 0; i < 64; ++i)
+        ctx->ai_history[i] = ctx->battery_curve[i];
+    ctx->power_mind_ready = TRUE;
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS PowerMind_RunAllPhases(KERNEL_CONTEXT *ctx) {
+    EFI_STATUS Status;
+    if ((Status = PowerMind_Phase901_ModelBatteryDischargeCurve(ctx))) return Status;
+    if ((Status = PowerMind_Phase902_IntegrateEntropyTrust(ctx))) return Status;
+    if ((Status = PowerMind_Phase903_ThrottlePhasesByPower(ctx))) return Status;
+    if ((Status = PowerMind_Phase904_ControlSmartTDP(ctx))) return Status;
+    if ((Status = PowerMind_Phase905_EvaluateIntentAlignment(ctx))) return Status;
+    if ((Status = PowerMind_Phase906_DetectDrainAnomaly(ctx))) return Status;
+    if ((Status = PowerMind_Phase907_VerifyVoltageStability(ctx))) return Status;
+    if ((Status = PowerMind_Phase908_TuneForIdle(ctx))) return Status;
+    if ((Status = PowerMind_Phase909_ForecastPhaseDemand(ctx))) return Status;
+    if ((Status = PowerMind_Phase910_CalculateBatteryTrustIndex(ctx))) return Status;
+    if ((Status = PowerMind_Phase911_LogEnergyTrustDeviation(ctx))) return Status;
+    if ((Status = PowerMind_Phase912_TriggerSafeMode(ctx))) return Status;
+    if ((Status = PowerMind_Phase913_MapReflectionCausality(ctx))) return Status;
+    if ((Status = PowerMind_Phase914_EstimateChargeSlope(ctx))) return Status;
+    if ((Status = PowerMind_Phase915_ModelEntropyImpact(ctx))) return Status;
+    if ((Status = PowerMind_Phase916_SyncWithVoltageEvents(ctx))) return Status;
+    if ((Status = PowerMind_Phase917_EmitFusionTelemetry(ctx))) return Status;
+    if ((Status = PowerMind_Phase918_CompensatePowerDrift(ctx))) return Status;
+    if ((Status = PowerMind_Phase919_ValidateThermalCoupling(ctx))) return Status;
+    if ((Status = PowerMind_Phase920_ForecastIntentCost(ctx))) return Status;
+    if ((Status = PowerMind_Phase921_IsolatePhaseEnergyAnomaly(ctx))) return Status;
+    if ((Status = PowerMind_Phase922_SynthesizeConfidenceScore(ctx))) return Status;
+    if ((Status = PowerMind_Phase923_AllocatePhasePower(ctx))) return Status;
+    if ((Status = PowerMind_Phase924_OrchestrateSleepDecision(ctx))) return Status;
+    if ((Status = PowerMind_Phase925_ScanBlindspots(ctx))) return Status;
+    if ((Status = PowerMind_Phase926_OptimizeTrustPowerCost(ctx))) return Status;
+    if ((Status = PowerMind_Phase927_ActivateOverpowerPrevention(ctx))) return Status;
+    if ((Status = PowerMind_Phase928_LogConvergence(ctx))) return Status;
+    if ((Status = PowerMind_Phase929_ApplyBackoffTimer(ctx))) return Status;
+    if ((Status = PowerMind_Phase930_FinalizePowerMind(ctx))) return Status;
+    return EFI_SUCCESS;
+}
+


### PR DESCRIPTION
## Summary
- add PowerMind header with phase prototypes
- implement power management phases 901-930
- extend `KERNEL_CONTEXT` with power mind fields

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_685cdc646ca0832f8b582b1113c5ffea