### PR TITLE
Implement power mind phases 931-950

### DIFF
--- a/include/power_mind.h
+++ b/include/power_mind.h
@@ -34,6 +34,26 @@ EFI_STATUS PowerMind_Phase927_ActivateOverpowerPrevention(KERNEL_CONTEXT *ctx);
 EFI_STATUS PowerMind_Phase928_LogConvergence(KERNEL_CONTEXT *ctx);
 EFI_STATUS PowerMind_Phase929_ApplyBackoffTimer(KERNEL_CONTEXT *ctx);
 EFI_STATUS PowerMind_Phase930_FinalizePowerMind(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase931_WatchForTrustViolations(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase932_ReallocateKernelPower(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase933_ForecastCollapse(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase934_TuneIntentToPowerEntropy(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase935_EnterUltraLowPower(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase936_LogPhaseEnergyAudit(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase937_BuildEnergyHeatmap(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase938_HandleMistrustEvent(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase939_BalanceIntentEnergy(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase940_PredictSleepDepth(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase941_ReschedulePhasesByPower(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase942_EnforceSaturationThreshold(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase943_MonitorConvergence(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase944_ClassifyPowerAnomalies(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase945_ValidateGPUVoltage(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase946_ForecastAgingCurve(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase947_HandleIntentCollisions(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase948_QuarantinePowerFaults(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase949_EmitDigest(KERNEL_CONTEXT *ctx);
+EFI_STATUS PowerMind_Phase950_FinalizeExecution(KERNEL_CONTEXT *ctx);
 
 EFI_STATUS PowerMind_RunAllPhases(KERNEL_CONTEXT *ctx);
 

--- a/kernel/kernel_shared.h
+++ b/kernel/kernel_shared.h
@@ -215,6 +215,14 @@ typedef struct {
     UINT64  power_confidence_score;
     UINT8   cpu_tdp_percent;
     BOOLEAN power_mind_ready;
+    UINT64  phase_energy_log[64];
+    UINTN   energy_log_index;
+    UINT64  energy_heatmap[10][10];
+    BOOLEAN power_precollapse_flag;
+    BOOLEAN power_guardian_mode;
+    BOOLEAN power_data_quarantined;
+    UINT8   predicted_sleep_state;
+    BOOLEAN power_mind_finalized;
 } KERNEL_CONTEXT;
 
 #endif // KERNEL_SHARED_H


### PR DESCRIPTION
## Summary
- expand power_mind to include phases 931-950
- log phase energy usage and build heatmap
- add power management fields in `KERNEL_CONTEXT`
- update headers and run loop

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_685cdd93e438832fa163bf814717771e