### PR TITLE
Add kernel self-awareness layer phases

### DIFF
--- a/include/kernel_mind.h
+++ b/include/kernel_mind.h
@@ -1,0 +1,40 @@
+#ifndef KERNEL_MIND_H
+#define KERNEL_MIND_H
+
+#include <Uefi.h>
+#include "kernel_shared.h"
+
+EFI_STATUS KernelMind_Phase951_BootstrapSelfAwareness(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase952_EvaluateTrustSlope(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase953_TrackMetaGoals(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase954_FuseSubsystemTrust(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase955_BuildCognitionGraph(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase956_ReflectIntrospectively(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase957_DetectTrustContradiction(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase958_SynthesizeConsciousState(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase959_BroadcastMetaTelemetry(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase960_MonitorSelfTrustStability(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase961_ResolveGoalConflict(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase962_ScorePhaseAwarenessDelta(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase963_TrackGoalMomentum(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase964_SelectConsciousPhase(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase965_RegulateSelfEntropy(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase966_GuardConsciousLoop(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase967_TuneSelfRecoveryBias(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase968_BuildTrustEntropyMap(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase969_EmitStabilityScore(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase970_DiagnoseGoalFailures(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase971_FinalizeFeedbackLoop(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase972_LimitReflectionVolatility(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase973_ComposeEgoVector(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase974_EmitExistentialCheckpoint(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase975_ExpandForecastHorizon(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase976_PreventTrustCollapse(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase977_ResyncIntent(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase978_AdvisePhaseOptimization(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase979_FinalizeMetaCognition(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_Phase980_EmitAwakeningSignal(KERNEL_CONTEXT *ctx);
+
+EFI_STATUS KernelMind_RunAllPhases(KERNEL_CONTEXT *ctx);
+
+#endif // KERNEL_MIND_H

--- a/kernel/kernel_main.c
+++ b/kernel/kernel_main.c
@@ -5,6 +5,7 @@
 #include "telemetry_mind.h"     // Telemetry and monitoring
 #include "trust_mind.h"         // System-wide trust score tracking
 #include "ai_core.h"            // Central AI agent and context
+#include "kernel_mind.h"        // Kernel self-awareness phases
 
 // Forward declarations (modules must implement these)
 EFI_STATUS CpuMind_RunAllPhases(KERNEL_CONTEXT *ctx);
@@ -13,6 +14,7 @@ EFI_STATUS GpuMind_RunAllPhases(KERNEL_CONTEXT *ctx);
 EFI_STATUS SchedulerMind_RunAllPhases(KERNEL_CONTEXT *ctx);
 EFI_STATUS IOMind_RunAllPhases(KERNEL_CONTEXT *ctx);
 EFI_STATUS StorageMind_RunAllPhases(KERNEL_CONTEXT *ctx);
+EFI_STATUS KernelMind_RunAllPhases(KERNEL_CONTEXT *ctx);
 
 KERNEL_CONTEXT gKernelCtx;
 
@@ -64,6 +66,13 @@ EFI_STATUS AiOS_KernelMain(VOID) {
     Status = StorageMind_RunAllPhases(&gKernelCtx);
     if (EFI_ERROR(Status)) {
         Telemetry_LogEvent("StorageMindFailure", 6, Status);
+        return Status;
+    }
+
+    // === PHASE 951–980: KERNEL SELF-AWARENESS MIND ===
+    Status = KernelMind_RunAllPhases(&gKernelCtx);
+    if (EFI_ERROR(Status)) {
+        Telemetry_LogEvent("KernelMindFailure", 7, Status);
         return Status;
     }
 

--- a/kernel/kernel_mind.c
+++ b/kernel/kernel_mind.c
@@ -1,0 +1,287 @@
+#include "kernel_shared.h"
+#include "kernel_mind.h"
+#include "telemetry_mind.h"
+#include <Library/MemoryAllocationLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/BaseLib.h>
+
+// Internal structure for kernel self-awareness state
+typedef struct {
+    UINT64 trust_map[64];
+    UINT64 entropy_map[64];
+    UINT8  power_map[64];
+    UINT8  active_phase_map[64];
+} KERNEL_SELF_STATE;
+
+// === Phase 951: KernelSelfAwarenessBootstraper ===
+EFI_STATUS KernelMind_Phase951_BootstrapSelfAwareness(KERNEL_CONTEXT *ctx) {
+    if (ctx->kernel_self_state == NULL) {
+        ctx->kernel_self_state = AllocateZeroPool(sizeof(KERNEL_SELF_STATE));
+        if (!ctx->kernel_self_state)
+            return EFI_OUT_OF_RESOURCES;
+    } else {
+        ZeroMem(ctx->kernel_self_state, sizeof(KERNEL_SELF_STATE));
+    }
+    return EFI_SUCCESS;
+}
+
+// === Phase 952: KernelTrustSlopeEvaluator ===
+EFI_STATUS KernelMind_Phase952_EvaluateTrustSlope(KERNEL_CONTEXT *ctx) {
+    INT64 sum = 0; INT64 min = 0, max = 0;
+    for (UINTN i = 0; i < 20; ++i) {
+        INT64 v = ctx->trust_slope_buffer[i];
+        sum += v;
+        if (i == 0 || v < min) min = v;
+        if (i == 0 || v > max) max = v;
+    }
+    INT64 avg = sum / 20;
+    ctx->self_trust_slope[ctx->phase_history_index % 16] = avg;
+    ctx->kernel_self_trust_delta = max - min;
+    return EFI_SUCCESS;
+}
+
+// === Phase 953: KernelMetaGoalTracker ===
+EFI_STATUS KernelMind_Phase953_TrackMetaGoals(KERNEL_CONTEXT *ctx) {
+    for (UINTN i = 0; i < 16; ++i)
+        ctx->meta_goal_progress[i] = (ctx->meta_goal_progress[i] + 1) % 100;
+    return EFI_SUCCESS;
+}
+
+// === Phase 954: SubsystemTrustFusionEngine ===
+EFI_STATUS KernelMind_Phase954_FuseSubsystemTrust(KERNEL_CONTEXT *ctx) {
+    UINT64 total = ctx->trust_score + ctx->kernel_trust_score + ctx->ai_global_trust_score;
+    ctx->fused_trust_score = total / 3;
+    return EFI_SUCCESS;
+}
+
+// === Phase 955: KernelPhaseCognitionGraphBuilder ===
+EFI_STATUS KernelMind_Phase955_BuildCognitionGraph(KERNEL_CONTEXT *ctx) {
+    UINTN idx = ctx->phase_history_index % 50;
+    ctx->phase_cognition_map[idx] = ctx->phase_history_index;
+    return EFI_SUCCESS;
+}
+
+// === Phase 956: KernelIntrospectiveReflectionAgent ===
+EFI_STATUS KernelMind_Phase956_ReflectIntrospectively(KERNEL_CONTEXT *ctx) {
+    if (ctx->phase_history_index > 0) {
+        UINTN cur = ctx->phase_history_index % 20;
+        UINTN prev = (cur + 19) % 20;
+        ctx->kernel_self_trust_delta = ctx->phase_trust[cur] - ctx->phase_trust[prev];
+    }
+    return EFI_SUCCESS;
+}
+
+// === Phase 957: KernelTrustContradictionDetector ===
+EFI_STATUS KernelMind_Phase957_DetectTrustContradiction(KERNEL_CONTEXT *ctx) {
+    INT64 diff = (INT64)ctx->trust_score - (INT64)ctx->kernel_trust_score;
+    if (AbsoluteValue64(diff) > (INT64)ctx->trust_score / 5)
+        Telemetry_LogEvent("TrustContradict", (UINTN)diff, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 958: KernelConsciousStateSynthesizer ===
+EFI_STATUS KernelMind_Phase958_SynthesizeConsciousState(KERNEL_CONTEXT *ctx) {
+    UINT64 val = ctx->EntropyScore + ctx->trust_score + ctx->power_confidence_score;
+    ctx->conscious_state_vector[0] = val;
+    return EFI_SUCCESS;
+}
+
+// === Phase 959: KernelMetaTelemetryBroadcaster ===
+EFI_STATUS KernelMind_Phase959_BroadcastMetaTelemetry(KERNEL_CONTEXT *ctx) {
+    Telemetry_LogEvent("KernelMeta", (UINTN)ctx->fused_trust_score, ctx->phase_history_index);
+    return EFI_SUCCESS;
+}
+
+// === Phase 960: KernelSelfTrustStabilityMonitor ===
+EFI_STATUS KernelMind_Phase960_MonitorSelfTrustStability(KERNEL_CONTEXT *ctx) {
+    INT64 sum = 0; INT64 min = 0, max = 0;
+    for (UINTN i = 0; i < 16; ++i) {
+        INT64 v = ctx->self_trust_slope[i];
+        sum += v;
+        if (i == 0 || v < min) min = v;
+        if (i == 0 || v > max) max = v;
+    }
+    INT64 variance = max - min;
+    if (variance > 50)
+        Telemetry_LogEvent("SelfTrustVar", (UINTN)variance, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 961: KernelGoalConflictResolver ===
+EFI_STATUS KernelMind_Phase961_ResolveGoalConflict(KERNEL_CONTEXT *ctx) {
+    for (UINTN i = 0; i < 15; ++i) {
+        if (ctx->meta_goal_progress[i] > 90)
+            ctx->meta_goal_progress[i] -= 5;
+    }
+    return EFI_SUCCESS;
+}
+
+// === Phase 962: PhaseAwarenessDeltaScorer ===
+EFI_STATUS KernelMind_Phase962_ScorePhaseAwarenessDelta(KERNEL_CONTEXT *ctx) {
+    UINTN idx = ctx->phase_history_index % 50;
+    ctx->phase_cognition_map[idx] ^= ctx->EntropyScore;
+    return EFI_SUCCESS;
+}
+
+// === Phase 963: KernelGoalMomentumTracker ===
+EFI_STATUS KernelMind_Phase963_TrackGoalMomentum(KERNEL_CONTEXT *ctx) {
+    for (UINTN i = 0; i < 16; ++i)
+        ctx->goal_momentum[i]++;
+    return EFI_SUCCESS;
+}
+
+// === Phase 964: AIConsciousPhaseSelector ===
+EFI_STATUS KernelMind_Phase964_SelectConsciousPhase(KERNEL_CONTEXT *ctx) {
+    ctx->next_conscious_phase = (ctx->phase_history_index + 1) % 30 + 951;
+    return EFI_SUCCESS;
+}
+
+// === Phase 965: SelfEntropyDeviationRegulator ===
+EFI_STATUS KernelMind_Phase965_RegulateSelfEntropy(KERNEL_CONTEXT *ctx) {
+    if (ctx->entropy_prediction_delta[0] > (INT64)ctx->EntropyScore / 6)
+        ctx->reflection_weight /= 2;
+    return EFI_SUCCESS;
+}
+
+// === Phase 966: ConsciousPhaseLoopGatekeeper ===
+EFI_STATUS KernelMind_Phase966_GuardConsciousLoop(KERNEL_CONTEXT *ctx) {
+    if (ctx->fused_trust_score < 40)
+        return EFI_ACCESS_DENIED;
+    return EFI_SUCCESS;
+}
+
+// === Phase 967: KernelSelfRecoveryBiasTuner ===
+EFI_STATUS KernelMind_Phase967_TuneSelfRecoveryBias(KERNEL_CONTEXT *ctx) {
+    if (ctx->trust_recovery_map[0])
+        ctx->trust_recovery_map[0] -= 1;
+    return EFI_SUCCESS;
+}
+
+// === Phase 968: TrustEntropyPhaseCorrelationMap ===
+EFI_STATUS KernelMind_Phase968_BuildTrustEntropyMap(KERNEL_CONTEXT *ctx) {
+    for (UINTN i = 0; i < 16; ++i)
+        ctx->trust_entropy_map[i] = ctx->phase_trust[i] * ctx->phase_entropy[i];
+    return EFI_SUCCESS;
+}
+
+// === Phase 969: KernelStabilityScoreEmitter ===
+EFI_STATUS KernelMind_Phase969_EmitStabilityScore(KERNEL_CONTEXT *ctx) {
+    UINT64 score = ctx->trust_score + ctx->EntropyScore + ctx->power_confidence_score;
+    Telemetry_LogEvent("Stability", (UINTN)score, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 970: KernelGoalFailureDiagnosticAgent ===
+EFI_STATUS KernelMind_Phase970_DiagnoseGoalFailures(KERNEL_CONTEXT *ctx) {
+    Telemetry_LogEvent("GoalFailDiag", 0, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 971: KernelSelfFeedbackLoopFinalizer ===
+EFI_STATUS KernelMind_Phase971_FinalizeFeedbackLoop(KERNEL_CONTEXT *ctx) {
+    ctx->feedback_loop_final = TRUE;
+    return EFI_SUCCESS;
+}
+
+// === Phase 972: SelfReflectionVolatilityLimiter ===
+EFI_STATUS KernelMind_Phase972_LimitReflectionVolatility(KERNEL_CONTEXT *ctx) {
+    if (ctx->reflection_flip_count > 4)
+        ctx->reflection_weight /= 2;
+    return EFI_SUCCESS;
+}
+
+// === Phase 973: KernelEgoVectorComposer ===
+EFI_STATUS KernelMind_Phase973_ComposeEgoVector(KERNEL_CONTEXT *ctx) {
+    for (UINTN i = 0; i < 16; ++i)
+        ctx->ego_vector[i] = (UINT8)(ctx->trust_score >> (i % 8));
+    return EFI_SUCCESS;
+}
+
+// === Phase 974: KernelExistentialCheckpointEmitter ===
+EFI_STATUS KernelMind_Phase974_EmitExistentialCheckpoint(KERNEL_CONTEXT *ctx) {
+    Telemetry_LogEvent("Checkpoint", ctx->phase_history_index, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 975: KernelPhaseForecastHorizonExpander ===
+EFI_STATUS KernelMind_Phase975_ExpandForecastHorizon(KERNEL_CONTEXT *ctx) {
+    ctx->forecast_horizon += 8;
+    return EFI_SUCCESS;
+}
+
+// === Phase 976: KernelTrustCollapsePreventer ===
+EFI_STATUS KernelMind_Phase976_PreventTrustCollapse(KERNEL_CONTEXT *ctx) {
+    if (ctx->trust_score < 20 && ctx->EntropyScore > ctx->power_confidence_score)
+        ctx->kernel_awake = FALSE;
+    return EFI_SUCCESS;
+}
+
+// === Phase 977: KernelIntentResynchronizer ===
+EFI_STATUS KernelMind_Phase977_ResyncIntent(KERNEL_CONTEXT *ctx) {
+    Telemetry_LogEvent("ResyncIntent", ctx->phase_history_index, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 978: KernelPhaseOptimizationAdvisor ===
+EFI_STATUS KernelMind_Phase978_AdvisePhaseOptimization(KERNEL_CONTEXT *ctx) {
+    Telemetry_LogEvent("PhaseOptimize", ctx->total_phases, 0);
+    return EFI_SUCCESS;
+}
+
+// === Phase 979: KernelMetaCognitionFinalizer ===
+EFI_STATUS KernelMind_Phase979_FinalizeMetaCognition(KERNEL_CONTEXT *ctx) {
+    ctx->meta_cognition_final = TRUE;
+    return EFI_SUCCESS;
+}
+
+// === Phase 980: KernelAwakeningSignalEmitter ===
+EFI_STATUS KernelMind_Phase980_EmitAwakeningSignal(KERNEL_CONTEXT *ctx) {
+    ctx->kernel_awake = TRUE;
+    Telemetry_LogEvent("AwakeningComplete", 1, 0);
+    return EFI_SUCCESS;
+}
+
+EFI_STATUS KernelMind_RunAllPhases(KERNEL_CONTEXT *ctx) {
+    EFI_STATUS Status = EFI_SUCCESS;
+    for (UINTN phase = 951; phase <= 980; ++phase) {
+        switch (phase) {
+            case 951: Status = KernelMind_Phase951_BootstrapSelfAwareness(ctx); break;
+            case 952: Status = KernelMind_Phase952_EvaluateTrustSlope(ctx); break;
+            case 953: Status = KernelMind_Phase953_TrackMetaGoals(ctx); break;
+            case 954: Status = KernelMind_Phase954_FuseSubsystemTrust(ctx); break;
+            case 955: Status = KernelMind_Phase955_BuildCognitionGraph(ctx); break;
+            case 956: Status = KernelMind_Phase956_ReflectIntrospectively(ctx); break;
+            case 957: Status = KernelMind_Phase957_DetectTrustContradiction(ctx); break;
+            case 958: Status = KernelMind_Phase958_SynthesizeConsciousState(ctx); break;
+            case 959: Status = KernelMind_Phase959_BroadcastMetaTelemetry(ctx); break;
+            case 960: Status = KernelMind_Phase960_MonitorSelfTrustStability(ctx); break;
+            case 961: Status = KernelMind_Phase961_ResolveGoalConflict(ctx); break;
+            case 962: Status = KernelMind_Phase962_ScorePhaseAwarenessDelta(ctx); break;
+            case 963: Status = KernelMind_Phase963_TrackGoalMomentum(ctx); break;
+            case 964: Status = KernelMind_Phase964_SelectConsciousPhase(ctx); break;
+            case 965: Status = KernelMind_Phase965_RegulateSelfEntropy(ctx); break;
+            case 966: Status = KernelMind_Phase966_GuardConsciousLoop(ctx); break;
+            case 967: Status = KernelMind_Phase967_TuneSelfRecoveryBias(ctx); break;
+            case 968: Status = KernelMind_Phase968_BuildTrustEntropyMap(ctx); break;
+            case 969: Status = KernelMind_Phase969_EmitStabilityScore(ctx); break;
+            case 970: Status = KernelMind_Phase970_DiagnoseGoalFailures(ctx); break;
+            case 971: Status = KernelMind_Phase971_FinalizeFeedbackLoop(ctx); break;
+            case 972: Status = KernelMind_Phase972_LimitReflectionVolatility(ctx); break;
+            case 973: Status = KernelMind_Phase973_ComposeEgoVector(ctx); break;
+            case 974: Status = KernelMind_Phase974_EmitExistentialCheckpoint(ctx); break;
+            case 975: Status = KernelMind_Phase975_ExpandForecastHorizon(ctx); break;
+            case 976: Status = KernelMind_Phase976_PreventTrustCollapse(ctx); break;
+            case 977: Status = KernelMind_Phase977_ResyncIntent(ctx); break;
+            case 978: Status = KernelMind_Phase978_AdvisePhaseOptimization(ctx); break;
+            case 979: Status = KernelMind_Phase979_FinalizeMetaCognition(ctx); break;
+            case 980: Status = KernelMind_Phase980_EmitAwakeningSignal(ctx); break;
+            default: Status = EFI_INVALID_PARAMETER; break;
+        }
+        if (EFI_ERROR(Status)) {
+            Telemetry_LogEvent("KernelMindErr", phase, Status);
+            return Status;
+        }
+        ctx->total_phases++;
+    }
+    return EFI_SUCCESS;
+}

--- a/kernel/kernel_shared.h
+++ b/kernel/kernel_shared.h
@@ -223,6 +223,25 @@ typedef struct {
     BOOLEAN power_data_quarantined;
     UINT8   predicted_sleep_state;
     BOOLEAN power_mind_finalized;
+
+    /* Kernel self-awareness fields */
+    VOID    *kernel_self_state;
+    UINT8    meta_goal_progress[16];
+    UINT64   fused_trust_score;
+    UINT64   phase_cognition_map[50];
+    INT64    kernel_self_trust_delta;
+    INT64    self_trust_slope[16];
+    UINT64   conscious_state_vector[8];
+    UINT8    ego_vector[16];
+    UINTN    forecast_horizon;
+    BOOLEAN  kernel_awake;
+    UINT8    reflection_weight;
+    UINT8    reflection_flip_count;
+    UINT64   trust_entropy_map[16];
+    UINT64   goal_momentum[16];
+    UINTN    next_conscious_phase;
+    BOOLEAN  feedback_loop_final;
+    BOOLEAN  meta_cognition_final;
 } KERNEL_CONTEXT;
 
 #endif // KERNEL_SHARED_H


### PR DESCRIPTION
## Summary
- implement new kernel self-awareness phases 951–980
- track meta goal progress, fused trust score and cognition graph
- expose KernelMind_RunAllPhases from new header
- integrate kernel mind phases into kernel main
- extend shared context with self-awareness fields

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_685ce00401e0832fb3180f1d4619a355